### PR TITLE
APPD-285: Fixed Command 'tagoio export'

### DIFF
--- a/src/commands/profile/export/export.ts
+++ b/src/commands/profile/export/export.ts
@@ -35,7 +35,7 @@ async function resolveTokens(userConfig: IExport, options: IExportOptions) {
   }
 
   if (!userConfig.import.token && !options.to) {
-    options.from = await pickEnvironment("Select the environment that will be receiving the application");
+    options.to = await pickEnvironment("Select the environment that will be receiving the application");
   }
 
   if (options.from) {


### PR DESCRIPTION
<!-- ### ATTENTION, BEFORE YOU OPEN THE PR CHECK -->

## What does PR do?

Fixed the 'Invalid Token' error that occurred when running the 'tagoio export' command.

## Type of alteration

- [x] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] Documentation update