### PR TITLE
fixed export for tago run new fields

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@tago-io/cli",
-  "version": "1.4.1",
+  "version": "1.5.0",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "@tago-io/cli",
-      "version": "1.4.1",
+      "version": "1.5.0",
       "license": "ISC",
       "dependencies": {
         "@swc-node/register": "^1.6.7",

--- a/package-lock.json
+++ b/package-lock.json
@@ -14,7 +14,7 @@
         "@swc/core": "^1.3.78",
         "@tago-io/sdk": "^11.0.6",
         "async": "^3.2.4",
-        "axios": "^1.4.0",
+        "axios": "^1.5.0",
         "commander": "^11.0.0",
         "dotenv": "^16.3.1",
         "envfile": "^6.18.0",
@@ -23,7 +23,7 @@
         "luxon": "^3.4.1",
         "prompts": "^2.4.2",
         "socket.io-client": "4.7.2",
-        "string-comparison": "^1.1.0"
+        "string-comparison": "^1.2.0"
       },
       "bin": {
         "tagoio": "build/index.js"
@@ -45,11 +45,11 @@
         "eslint-plugin-jest": "27.2.3",
         "eslint-plugin-prettier": "5.0.0",
         "eslint-plugin-unicorn": "48.0.1",
-        "jest": "29.6.3",
+        "jest": "29.6.4",
         "prettier": "3.0.2",
         "ts-jest": "^29.1.1",
         "ts-node-dev": "2.0.0",
-        "typescript": "^5.1.6"
+        "typescript": "^5.2.2"
       },
       "engines": {
         "node": ">=17.0.0",
@@ -136,9 +136,9 @@
       "dev": true
     },
     "node_modules/@babel/core/node_modules/semver": {
-      "version": "6.3.0",
-      "resolved": "https://registry.npmjs.org/semver/-/semver-6.3.0.tgz",
-      "integrity": "sha512-b39TBaTSfV6yBrapU89p5fKekE2m/NwnDocOVruQFS1/veMgdzuPcnOM34M6CwxW8jH/lxEa5rBoDeUwu5HHTw==",
+      "version": "6.3.1",
+      "resolved": "https://registry.npmjs.org/semver/-/semver-6.3.1.tgz",
+      "integrity": "sha512-BR7VvDCVHO+q2xBEWskxS6DJE1qRnb7DxzUrogb71CWoSficBxYsiAGd+Kl0mmq/MprG9yArRkyrQxTO6XjMzA==",
       "dev": true,
       "bin": {
         "semver": "bin/semver.js"
@@ -203,9 +203,9 @@
       }
     },
     "node_modules/@babel/helper-compilation-targets/node_modules/semver": {
-      "version": "6.3.0",
-      "resolved": "https://registry.npmjs.org/semver/-/semver-6.3.0.tgz",
-      "integrity": "sha512-b39TBaTSfV6yBrapU89p5fKekE2m/NwnDocOVruQFS1/veMgdzuPcnOM34M6CwxW8jH/lxEa5rBoDeUwu5HHTw==",
+      "version": "6.3.1",
+      "resolved": "https://registry.npmjs.org/semver/-/semver-6.3.1.tgz",
+      "integrity": "sha512-BR7VvDCVHO+q2xBEWskxS6DJE1qRnb7DxzUrogb71CWoSficBxYsiAGd+Kl0mmq/MprG9yArRkyrQxTO6XjMzA==",
       "dev": true,
       "bin": {
         "semver": "bin/semver.js"
@@ -908,9 +908,9 @@
       }
     },
     "node_modules/@jest/console": {
-      "version": "29.6.3",
-      "resolved": "https://registry.npmjs.org/@jest/console/-/console-29.6.3.tgz",
-      "integrity": "sha512-ukZbHAdDH4ktZIOKvWs1juAXhiVAdvCyM8zv4S/7Ii3vJSDvMW5k+wOVGMQmHLHUFw3Ko63ZQNy7NI6PSlsD5w==",
+      "version": "29.6.4",
+      "resolved": "https://registry.npmjs.org/@jest/console/-/console-29.6.4.tgz",
+      "integrity": "sha512-wNK6gC0Ha9QeEPSkeJedQuTQqxZYnDPuDcDhVuVatRvMkL4D0VTvFVZj+Yuh6caG2aOfzkUZ36KtCmLNtR02hw==",
       "dev": true,
       "dependencies": {
         "@jest/types": "^29.6.3",
@@ -925,15 +925,15 @@
       }
     },
     "node_modules/@jest/core": {
-      "version": "29.6.3",
-      "resolved": "https://registry.npmjs.org/@jest/core/-/core-29.6.3.tgz",
-      "integrity": "sha512-skV1XrfNxfagmjRUrk2FyN5/2YwIzdWVVBa/orUfbLvQUANXxERq2pTvY0I+FinWHjDKB2HRmpveUiph4X0TJw==",
+      "version": "29.6.4",
+      "resolved": "https://registry.npmjs.org/@jest/core/-/core-29.6.4.tgz",
+      "integrity": "sha512-U/vq5ccNTSVgYH7mHnodHmCffGWHJnz/E1BEWlLuK5pM4FZmGfBn/nrJGLjUsSmyx3otCeqc1T31F4y08AMDLg==",
       "dev": true,
       "dependencies": {
-        "@jest/console": "^29.6.3",
-        "@jest/reporters": "^29.6.3",
-        "@jest/test-result": "^29.6.3",
-        "@jest/transform": "^29.6.3",
+        "@jest/console": "^29.6.4",
+        "@jest/reporters": "^29.6.4",
+        "@jest/test-result": "^29.6.4",
+        "@jest/transform": "^29.6.4",
         "@jest/types": "^29.6.3",
         "@types/node": "*",
         "ansi-escapes": "^4.2.1",
@@ -942,18 +942,18 @@
         "exit": "^0.1.2",
         "graceful-fs": "^4.2.9",
         "jest-changed-files": "^29.6.3",
-        "jest-config": "^29.6.3",
-        "jest-haste-map": "^29.6.3",
+        "jest-config": "^29.6.4",
+        "jest-haste-map": "^29.6.4",
         "jest-message-util": "^29.6.3",
         "jest-regex-util": "^29.6.3",
-        "jest-resolve": "^29.6.3",
-        "jest-resolve-dependencies": "^29.6.3",
-        "jest-runner": "^29.6.3",
-        "jest-runtime": "^29.6.3",
-        "jest-snapshot": "^29.6.3",
+        "jest-resolve": "^29.6.4",
+        "jest-resolve-dependencies": "^29.6.4",
+        "jest-runner": "^29.6.4",
+        "jest-runtime": "^29.6.4",
+        "jest-snapshot": "^29.6.4",
         "jest-util": "^29.6.3",
         "jest-validate": "^29.6.3",
-        "jest-watcher": "^29.6.3",
+        "jest-watcher": "^29.6.4",
         "micromatch": "^4.0.4",
         "pretty-format": "^29.6.3",
         "slash": "^3.0.0",
@@ -972,12 +972,12 @@
       }
     },
     "node_modules/@jest/environment": {
-      "version": "29.6.3",
-      "resolved": "https://registry.npmjs.org/@jest/environment/-/environment-29.6.3.tgz",
-      "integrity": "sha512-u/u3cCztYCfgBiGHsamqP5x+XvucftOGPbf5RJQxfpeC1y4AL8pCjKvPDA3oCmdhZYPgk5AE0VOD/flweR69WA==",
+      "version": "29.6.4",
+      "resolved": "https://registry.npmjs.org/@jest/environment/-/environment-29.6.4.tgz",
+      "integrity": "sha512-sQ0SULEjA1XUTHmkBRl7A1dyITM9yb1yb3ZNKPX3KlTd6IG7mWUe3e2yfExtC2Zz1Q+mMckOLHmL/qLiuQJrBQ==",
       "dev": true,
       "dependencies": {
-        "@jest/fake-timers": "^29.6.3",
+        "@jest/fake-timers": "^29.6.4",
         "@jest/types": "^29.6.3",
         "@types/node": "*",
         "jest-mock": "^29.6.3"
@@ -987,22 +987,22 @@
       }
     },
     "node_modules/@jest/expect": {
-      "version": "29.6.3",
-      "resolved": "https://registry.npmjs.org/@jest/expect/-/expect-29.6.3.tgz",
-      "integrity": "sha512-Ic08XbI2jlg6rECy+CGwk/8NDa6VE7UmIG6++9OTPAMnQmNGY28hu69Nf629CWv6T7YMODLbONxDFKdmQeI9FA==",
+      "version": "29.6.4",
+      "resolved": "https://registry.npmjs.org/@jest/expect/-/expect-29.6.4.tgz",
+      "integrity": "sha512-Warhsa7d23+3X5bLbrbYvaehcgX5TLYhI03JKoedTiI8uJU4IhqYBWF7OSSgUyz4IgLpUYPkK0AehA5/fRclAA==",
       "dev": true,
       "dependencies": {
-        "expect": "^29.6.3",
-        "jest-snapshot": "^29.6.3"
+        "expect": "^29.6.4",
+        "jest-snapshot": "^29.6.4"
       },
       "engines": {
         "node": "^14.15.0 || ^16.10.0 || >=18.0.0"
       }
     },
     "node_modules/@jest/expect-utils": {
-      "version": "29.6.3",
-      "resolved": "https://registry.npmjs.org/@jest/expect-utils/-/expect-utils-29.6.3.tgz",
-      "integrity": "sha512-nvOEW4YoqRKD9HBJ9OJ6przvIvP9qilp5nAn1462P5ZlL/MM9SgPEZFyjTGPfs7QkocdUsJa6KjHhyRn4ueItA==",
+      "version": "29.6.4",
+      "resolved": "https://registry.npmjs.org/@jest/expect-utils/-/expect-utils-29.6.4.tgz",
+      "integrity": "sha512-FEhkJhqtvBwgSpiTrocquJCdXPsyvNKcl/n7A3u7X4pVoF4bswm11c9d4AV+kfq2Gpv/mM8x7E7DsRvH+djkrg==",
       "dev": true,
       "dependencies": {
         "jest-get-type": "^29.6.3"
@@ -1012,9 +1012,9 @@
       }
     },
     "node_modules/@jest/fake-timers": {
-      "version": "29.6.3",
-      "resolved": "https://registry.npmjs.org/@jest/fake-timers/-/fake-timers-29.6.3.tgz",
-      "integrity": "sha512-pa1wmqvbj6eX0nMvOM2VDAWvJOI5A/Mk3l8O7n7EsAh71sMZblaKO9iT4GjIj0LwwK3CP/Jp1ypEV0x3m89RvA==",
+      "version": "29.6.4",
+      "resolved": "https://registry.npmjs.org/@jest/fake-timers/-/fake-timers-29.6.4.tgz",
+      "integrity": "sha512-6UkCwzoBK60edXIIWb0/KWkuj7R7Qq91vVInOe3De6DSpaEiqjKcJw4F7XUet24Wupahj9J6PlR09JqJ5ySDHw==",
       "dev": true,
       "dependencies": {
         "@jest/types": "^29.6.3",
@@ -1029,13 +1029,13 @@
       }
     },
     "node_modules/@jest/globals": {
-      "version": "29.6.3",
-      "resolved": "https://registry.npmjs.org/@jest/globals/-/globals-29.6.3.tgz",
-      "integrity": "sha512-RB+uI+CZMHntzlnOPlll5x/jgRff3LEPl/td/jzMXiIgR0iIhKq9qm1HLU+EC52NuoVy/1swit/sDGjVn4bc6A==",
+      "version": "29.6.4",
+      "resolved": "https://registry.npmjs.org/@jest/globals/-/globals-29.6.4.tgz",
+      "integrity": "sha512-wVIn5bdtjlChhXAzVXavcY/3PEjf4VqM174BM3eGL5kMxLiZD5CLnbmkEyA1Dwh9q8XjP6E8RwjBsY/iCWrWsA==",
       "dev": true,
       "dependencies": {
-        "@jest/environment": "^29.6.3",
-        "@jest/expect": "^29.6.3",
+        "@jest/environment": "^29.6.4",
+        "@jest/expect": "^29.6.4",
         "@jest/types": "^29.6.3",
         "jest-mock": "^29.6.3"
       },
@@ -1044,15 +1044,15 @@
       }
     },
     "node_modules/@jest/reporters": {
-      "version": "29.6.3",
-      "resolved": "https://registry.npmjs.org/@jest/reporters/-/reporters-29.6.3.tgz",
-      "integrity": "sha512-kGz59zMi0GkVjD2CJeYWG9k6cvj7eBqt9aDAqo2rcCLRTYlvQ62Gu/n+tOmJMBHGjzeijjuCENjzTyYBgrtLUw==",
+      "version": "29.6.4",
+      "resolved": "https://registry.npmjs.org/@jest/reporters/-/reporters-29.6.4.tgz",
+      "integrity": "sha512-sxUjWxm7QdchdrD3NfWKrL8FBsortZeibSJv4XLjESOOjSUOkjQcb0ZHJwfhEGIvBvTluTzfG2yZWZhkrXJu8g==",
       "dev": true,
       "dependencies": {
         "@bcoe/v8-coverage": "^0.2.3",
-        "@jest/console": "^29.6.3",
-        "@jest/test-result": "^29.6.3",
-        "@jest/transform": "^29.6.3",
+        "@jest/console": "^29.6.4",
+        "@jest/test-result": "^29.6.4",
+        "@jest/transform": "^29.6.4",
         "@jest/types": "^29.6.3",
         "@jridgewell/trace-mapping": "^0.3.18",
         "@types/node": "*",
@@ -1068,7 +1068,7 @@
         "istanbul-reports": "^3.1.3",
         "jest-message-util": "^29.6.3",
         "jest-util": "^29.6.3",
-        "jest-worker": "^29.6.3",
+        "jest-worker": "^29.6.4",
         "slash": "^3.0.0",
         "string-length": "^4.0.1",
         "strip-ansi": "^6.0.0",
@@ -1129,12 +1129,12 @@
       }
     },
     "node_modules/@jest/test-result": {
-      "version": "29.6.3",
-      "resolved": "https://registry.npmjs.org/@jest/test-result/-/test-result-29.6.3.tgz",
-      "integrity": "sha512-k7ZZaNvOSMBHPZYiy0kuiaFoyansR5QnTwDux1EjK3kD5iWpRVyJIJ0RAIV39SThafchuW59vra7F8mdy5Hfgw==",
+      "version": "29.6.4",
+      "resolved": "https://registry.npmjs.org/@jest/test-result/-/test-result-29.6.4.tgz",
+      "integrity": "sha512-uQ1C0AUEN90/dsyEirgMLlouROgSY+Wc/JanVVk0OiUKa5UFh7sJpMEM3aoUBAz2BRNvUJ8j3d294WFuRxSyOQ==",
       "dev": true,
       "dependencies": {
-        "@jest/console": "^29.6.3",
+        "@jest/console": "^29.6.4",
         "@jest/types": "^29.6.3",
         "@types/istanbul-lib-coverage": "^2.0.0",
         "collect-v8-coverage": "^1.0.0"
@@ -1144,14 +1144,14 @@
       }
     },
     "node_modules/@jest/test-sequencer": {
-      "version": "29.6.3",
-      "resolved": "https://registry.npmjs.org/@jest/test-sequencer/-/test-sequencer-29.6.3.tgz",
-      "integrity": "sha512-/SmijaAU2TY9ComFGIYa6Z+fmKqQMnqs2Nmwb0P/Z/tROdZ7M0iruES1EaaU9PBf8o9uED5xzaJ3YPFEIcDgAg==",
+      "version": "29.6.4",
+      "resolved": "https://registry.npmjs.org/@jest/test-sequencer/-/test-sequencer-29.6.4.tgz",
+      "integrity": "sha512-E84M6LbpcRq3fT4ckfKs9ryVanwkaIB0Ws9bw3/yP4seRLg/VaCZ/LgW0MCq5wwk4/iP/qnilD41aj2fsw2RMg==",
       "dev": true,
       "dependencies": {
-        "@jest/test-result": "^29.6.3",
+        "@jest/test-result": "^29.6.4",
         "graceful-fs": "^4.2.9",
-        "jest-haste-map": "^29.6.3",
+        "jest-haste-map": "^29.6.4",
         "slash": "^3.0.0"
       },
       "engines": {
@@ -1159,9 +1159,9 @@
       }
     },
     "node_modules/@jest/transform": {
-      "version": "29.6.3",
-      "resolved": "https://registry.npmjs.org/@jest/transform/-/transform-29.6.3.tgz",
-      "integrity": "sha512-dPIc3DsvMZ/S8ut4L2ViCj265mKO0owB0wfzBv2oGzL9pQ+iRvJewHqLBmsGb7XFb5UotWIEtvY5A/lnylaIoQ==",
+      "version": "29.6.4",
+      "resolved": "https://registry.npmjs.org/@jest/transform/-/transform-29.6.4.tgz",
+      "integrity": "sha512-8thgRSiXUqtr/pPGY/OsyHuMjGyhVnWrFAwoxmIemlBuiMyU1WFs0tXoNxzcr4A4uErs/ABre76SGmrr5ab/AA==",
       "dev": true,
       "dependencies": {
         "@babel/core": "^7.11.6",
@@ -1172,7 +1172,7 @@
         "convert-source-map": "^2.0.0",
         "fast-json-stable-stringify": "^2.1.0",
         "graceful-fs": "^4.2.9",
-        "jest-haste-map": "^29.6.3",
+        "jest-haste-map": "^29.6.4",
         "jest-regex-util": "^29.6.3",
         "jest-util": "^29.6.3",
         "micromatch": "^4.0.4",
@@ -1658,6 +1658,16 @@
       "engines": {
         "node": ">=14.0.0",
         "npm": ">=6.0.0"
+      }
+    },
+    "node_modules/@tago-io/sdk/node_modules/axios": {
+      "version": "1.4.0",
+      "resolved": "https://registry.npmjs.org/axios/-/axios-1.4.0.tgz",
+      "integrity": "sha512-S4XCWMEmzvo64T9GfvQDOXgYRDJ/wsSZc7Jvdgx5u1sd0JwsuPLqb3SYmusag+edF6ziyMensPVqLTSc1PiSEA==",
+      "dependencies": {
+        "follow-redirects": "^1.15.0",
+        "form-data": "^4.0.0",
+        "proxy-from-env": "^1.1.0"
       }
     },
     "node_modules/@tago-io/sdk/node_modules/engine.io-client": {
@@ -2680,9 +2690,9 @@
       }
     },
     "node_modules/axios": {
-      "version": "1.4.0",
-      "resolved": "https://registry.npmjs.org/axios/-/axios-1.4.0.tgz",
-      "integrity": "sha512-S4XCWMEmzvo64T9GfvQDOXgYRDJ/wsSZc7Jvdgx5u1sd0JwsuPLqb3SYmusag+edF6ziyMensPVqLTSc1PiSEA==",
+      "version": "1.5.0",
+      "resolved": "https://registry.npmjs.org/axios/-/axios-1.5.0.tgz",
+      "integrity": "sha512-D4DdjDo5CY50Qms0qGQTTw6Q44jl7zRwY7bthds06pUGfChBCTcQs+N743eFWGEd6pRTMd6A+I87aWyFV5wiZQ==",
       "dependencies": {
         "follow-redirects": "^1.15.0",
         "form-data": "^4.0.0",
@@ -2690,12 +2700,12 @@
       }
     },
     "node_modules/babel-jest": {
-      "version": "29.6.3",
-      "resolved": "https://registry.npmjs.org/babel-jest/-/babel-jest-29.6.3.tgz",
-      "integrity": "sha512-1Ne93zZZEy5XmTa4Q+W5+zxBrDpExX8E3iy+xJJ+24ewlfo/T3qHfQJCzi/MMVFmBQDNxtRR/Gfd2dwb/0yrQw==",
+      "version": "29.6.4",
+      "resolved": "https://registry.npmjs.org/babel-jest/-/babel-jest-29.6.4.tgz",
+      "integrity": "sha512-meLj23UlSLddj6PC+YTOFRgDAtjnZom8w/ACsrx0gtPtv5cJZk0A5Unk5bV4wixD7XaPCN1fQvpww8czkZURmw==",
       "dev": true,
       "dependencies": {
-        "@jest/transform": "^29.6.3",
+        "@jest/transform": "^29.6.4",
         "@types/babel__core": "^7.1.14",
         "babel-plugin-istanbul": "^6.1.1",
         "babel-preset-jest": "^29.6.3",
@@ -4558,14 +4568,14 @@
       }
     },
     "node_modules/expect": {
-      "version": "29.6.3",
-      "resolved": "https://registry.npmjs.org/expect/-/expect-29.6.3.tgz",
-      "integrity": "sha512-x1vY4LlEMWUYVZQrFi4ZANXFwqYbJ/JNQspLVvzhW2BNY28aNcXMQH6imBbt+RBf5sVRTodYHXtSP/TLEU0Dxw==",
+      "version": "29.6.4",
+      "resolved": "https://registry.npmjs.org/expect/-/expect-29.6.4.tgz",
+      "integrity": "sha512-F2W2UyQ8XYyftHT57dtfg8Ue3X5qLgm2sSug0ivvLRH/VKNRL/pDxg/TH7zVzbQB0tu80clNFy6LU7OS/VSEKA==",
       "dev": true,
       "dependencies": {
-        "@jest/expect-utils": "^29.6.3",
+        "@jest/expect-utils": "^29.6.4",
         "jest-get-type": "^29.6.3",
-        "jest-matcher-utils": "^29.6.3",
+        "jest-matcher-utils": "^29.6.4",
         "jest-message-util": "^29.6.3",
         "jest-util": "^29.6.3"
       },
@@ -5710,9 +5720,9 @@
       }
     },
     "node_modules/istanbul-lib-instrument/node_modules/semver": {
-      "version": "6.3.0",
-      "resolved": "https://registry.npmjs.org/semver/-/semver-6.3.0.tgz",
-      "integrity": "sha512-b39TBaTSfV6yBrapU89p5fKekE2m/NwnDocOVruQFS1/veMgdzuPcnOM34M6CwxW8jH/lxEa5rBoDeUwu5HHTw==",
+      "version": "6.3.1",
+      "resolved": "https://registry.npmjs.org/semver/-/semver-6.3.1.tgz",
+      "integrity": "sha512-BR7VvDCVHO+q2xBEWskxS6DJE1qRnb7DxzUrogb71CWoSficBxYsiAGd+Kl0mmq/MprG9yArRkyrQxTO6XjMzA==",
       "dev": true,
       "bin": {
         "semver": "bin/semver.js"
@@ -5760,15 +5770,15 @@
       }
     },
     "node_modules/jest": {
-      "version": "29.6.3",
-      "resolved": "https://registry.npmjs.org/jest/-/jest-29.6.3.tgz",
-      "integrity": "sha512-alueLuoPCDNHFcFGmgETR4KpQ+0ff3qVaiJwxQM4B5sC0CvXcgg4PEi7xrDkxuItDmdz/FVc7SSit4KEu8GRvw==",
+      "version": "29.6.4",
+      "resolved": "https://registry.npmjs.org/jest/-/jest-29.6.4.tgz",
+      "integrity": "sha512-tEFhVQFF/bzoYV1YuGyzLPZ6vlPrdfvDmmAxudA1dLEuiztqg2Rkx20vkKY32xiDROcD2KXlgZ7Cu8RPeEHRKw==",
       "dev": true,
       "dependencies": {
-        "@jest/core": "^29.6.3",
+        "@jest/core": "^29.6.4",
         "@jest/types": "^29.6.3",
         "import-local": "^3.0.2",
-        "jest-cli": "^29.6.3"
+        "jest-cli": "^29.6.4"
       },
       "bin": {
         "jest": "bin/jest.js"
@@ -5859,14 +5869,14 @@
       }
     },
     "node_modules/jest-circus": {
-      "version": "29.6.3",
-      "resolved": "https://registry.npmjs.org/jest-circus/-/jest-circus-29.6.3.tgz",
-      "integrity": "sha512-p0R5YqZEMnOpHqHLWRSjm2z/0p6RNsrNE/GRRT3eli8QGOAozj6Ys/3Tv+Ej+IfltJoSPwcQ6/hOCRkNlxLLCw==",
+      "version": "29.6.4",
+      "resolved": "https://registry.npmjs.org/jest-circus/-/jest-circus-29.6.4.tgz",
+      "integrity": "sha512-YXNrRyntVUgDfZbjXWBMPslX1mQ8MrSG0oM/Y06j9EYubODIyHWP8hMUbjbZ19M3M+zamqEur7O80HODwACoJw==",
       "dev": true,
       "dependencies": {
-        "@jest/environment": "^29.6.3",
-        "@jest/expect": "^29.6.3",
-        "@jest/test-result": "^29.6.3",
+        "@jest/environment": "^29.6.4",
+        "@jest/expect": "^29.6.4",
+        "@jest/test-result": "^29.6.4",
         "@jest/types": "^29.6.3",
         "@types/node": "*",
         "chalk": "^4.0.0",
@@ -5874,10 +5884,10 @@
         "dedent": "^1.0.0",
         "is-generator-fn": "^2.0.0",
         "jest-each": "^29.6.3",
-        "jest-matcher-utils": "^29.6.3",
+        "jest-matcher-utils": "^29.6.4",
         "jest-message-util": "^29.6.3",
-        "jest-runtime": "^29.6.3",
-        "jest-snapshot": "^29.6.3",
+        "jest-runtime": "^29.6.4",
+        "jest-snapshot": "^29.6.4",
         "jest-util": "^29.6.3",
         "p-limit": "^3.1.0",
         "pretty-format": "^29.6.3",
@@ -5890,19 +5900,19 @@
       }
     },
     "node_modules/jest-cli": {
-      "version": "29.6.3",
-      "resolved": "https://registry.npmjs.org/jest-cli/-/jest-cli-29.6.3.tgz",
-      "integrity": "sha512-KuPdXUPXQIf0t6DvmG8MV4QyhcjR1a6ruKl3YL7aGn/AQ8JkROwFkWzEpDIpt11Qy188dHbRm8WjwMsV/4nmnQ==",
+      "version": "29.6.4",
+      "resolved": "https://registry.npmjs.org/jest-cli/-/jest-cli-29.6.4.tgz",
+      "integrity": "sha512-+uMCQ7oizMmh8ZwRfZzKIEszFY9ksjjEQnTEMTaL7fYiL3Kw4XhqT9bYh+A4DQKUb67hZn2KbtEnDuHvcgK4pQ==",
       "dev": true,
       "dependencies": {
-        "@jest/core": "^29.6.3",
-        "@jest/test-result": "^29.6.3",
+        "@jest/core": "^29.6.4",
+        "@jest/test-result": "^29.6.4",
         "@jest/types": "^29.6.3",
         "chalk": "^4.0.0",
         "exit": "^0.1.2",
         "graceful-fs": "^4.2.9",
         "import-local": "^3.0.2",
-        "jest-config": "^29.6.3",
+        "jest-config": "^29.6.4",
         "jest-util": "^29.6.3",
         "jest-validate": "^29.6.3",
         "prompts": "^2.0.1",
@@ -5924,26 +5934,26 @@
       }
     },
     "node_modules/jest-config": {
-      "version": "29.6.3",
-      "resolved": "https://registry.npmjs.org/jest-config/-/jest-config-29.6.3.tgz",
-      "integrity": "sha512-nb9bOq2aEqogbyL4F9mLkAeQGAgNt7Uz6U59YtQDIxFPiL7Ejgq0YIrp78oyEHD6H4CIV/k7mFrK7eFDzUJ69w==",
+      "version": "29.6.4",
+      "resolved": "https://registry.npmjs.org/jest-config/-/jest-config-29.6.4.tgz",
+      "integrity": "sha512-JWohr3i9m2cVpBumQFv2akMEnFEPVOh+9L2xIBJhJ0zOaci2ZXuKJj0tgMKQCBZAKA09H049IR4HVS/43Qb19A==",
       "dev": true,
       "dependencies": {
         "@babel/core": "^7.11.6",
-        "@jest/test-sequencer": "^29.6.3",
+        "@jest/test-sequencer": "^29.6.4",
         "@jest/types": "^29.6.3",
-        "babel-jest": "^29.6.3",
+        "babel-jest": "^29.6.4",
         "chalk": "^4.0.0",
         "ci-info": "^3.2.0",
         "deepmerge": "^4.2.2",
         "glob": "^7.1.3",
         "graceful-fs": "^4.2.9",
-        "jest-circus": "^29.6.3",
-        "jest-environment-node": "^29.6.3",
+        "jest-circus": "^29.6.4",
+        "jest-environment-node": "^29.6.4",
         "jest-get-type": "^29.6.3",
         "jest-regex-util": "^29.6.3",
-        "jest-resolve": "^29.6.3",
-        "jest-runner": "^29.6.3",
+        "jest-resolve": "^29.6.4",
+        "jest-runner": "^29.6.4",
         "jest-util": "^29.6.3",
         "jest-validate": "^29.6.3",
         "micromatch": "^4.0.4",
@@ -5969,9 +5979,9 @@
       }
     },
     "node_modules/jest-diff": {
-      "version": "29.6.3",
-      "resolved": "https://registry.npmjs.org/jest-diff/-/jest-diff-29.6.3.tgz",
-      "integrity": "sha512-3sw+AdWnwH9sSNohMRKA7JiYUJSRr/WS6+sEFfBuhxU5V5GlEVKfvUn8JuMHE0wqKowemR1C2aHy8VtXbaV8dQ==",
+      "version": "29.6.4",
+      "resolved": "https://registry.npmjs.org/jest-diff/-/jest-diff-29.6.4.tgz",
+      "integrity": "sha512-9F48UxR9e4XOEZvoUXEHSWY4qC4zERJaOfrbBg9JpbJOO43R1vN76REt/aMGZoY6GD5g84nnJiBIVlscegefpw==",
       "dev": true,
       "dependencies": {
         "chalk": "^4.0.0",
@@ -6012,13 +6022,13 @@
       }
     },
     "node_modules/jest-environment-node": {
-      "version": "29.6.3",
-      "resolved": "https://registry.npmjs.org/jest-environment-node/-/jest-environment-node-29.6.3.tgz",
-      "integrity": "sha512-PKl7upfPJXMYbWpD+60o4HP86KvFO2c9dZ+Zr6wUzsG5xcPx/65o3ArNgHW5M0RFvLYdW4/aieR4JSooD0a2ew==",
+      "version": "29.6.4",
+      "resolved": "https://registry.npmjs.org/jest-environment-node/-/jest-environment-node-29.6.4.tgz",
+      "integrity": "sha512-i7SbpH2dEIFGNmxGCpSc2w9cA4qVD+wfvg2ZnfQ7XVrKL0NA5uDVBIiGH8SR4F0dKEv/0qI5r+aDomDf04DpEQ==",
       "dev": true,
       "dependencies": {
-        "@jest/environment": "^29.6.3",
-        "@jest/fake-timers": "^29.6.3",
+        "@jest/environment": "^29.6.4",
+        "@jest/fake-timers": "^29.6.4",
         "@jest/types": "^29.6.3",
         "@types/node": "*",
         "jest-mock": "^29.6.3",
@@ -6038,9 +6048,9 @@
       }
     },
     "node_modules/jest-haste-map": {
-      "version": "29.6.3",
-      "resolved": "https://registry.npmjs.org/jest-haste-map/-/jest-haste-map-29.6.3.tgz",
-      "integrity": "sha512-GecR5YavfjkhOytEFHAeI6aWWG3f/cOKNB1YJvj/B76xAmeVjy4zJUYobGF030cRmKaO1FBw3V8CZZ6KVh9ZSw==",
+      "version": "29.6.4",
+      "resolved": "https://registry.npmjs.org/jest-haste-map/-/jest-haste-map-29.6.4.tgz",
+      "integrity": "sha512-12Ad+VNTDHxKf7k+M65sviyynRoZYuL1/GTuhEVb8RYsNSNln71nANRb/faSyWvx0j+gHcivChXHIoMJrGYjog==",
       "dev": true,
       "dependencies": {
         "@jest/types": "^29.6.3",
@@ -6051,7 +6061,7 @@
         "graceful-fs": "^4.2.9",
         "jest-regex-util": "^29.6.3",
         "jest-util": "^29.6.3",
-        "jest-worker": "^29.6.3",
+        "jest-worker": "^29.6.4",
         "micromatch": "^4.0.4",
         "walker": "^1.0.8"
       },
@@ -6076,13 +6086,13 @@
       }
     },
     "node_modules/jest-matcher-utils": {
-      "version": "29.6.3",
-      "resolved": "https://registry.npmjs.org/jest-matcher-utils/-/jest-matcher-utils-29.6.3.tgz",
-      "integrity": "sha512-6ZrMYINZdwduSt5Xu18/n49O1IgXdjsfG7NEZaQws9k69eTKWKcVbJBw/MZsjOZe2sSyJFmuzh8042XWwl54Zg==",
+      "version": "29.6.4",
+      "resolved": "https://registry.npmjs.org/jest-matcher-utils/-/jest-matcher-utils-29.6.4.tgz",
+      "integrity": "sha512-KSzwyzGvK4HcfnserYqJHYi7sZVqdREJ9DMPAKVbS98JsIAvumihaNUbjrWw0St7p9IY7A9UskCW5MYlGmBQFQ==",
       "dev": true,
       "dependencies": {
         "chalk": "^4.0.0",
-        "jest-diff": "^29.6.3",
+        "jest-diff": "^29.6.4",
         "jest-get-type": "^29.6.3",
         "pretty-format": "^29.6.3"
       },
@@ -6151,14 +6161,14 @@
       }
     },
     "node_modules/jest-resolve": {
-      "version": "29.6.3",
-      "resolved": "https://registry.npmjs.org/jest-resolve/-/jest-resolve-29.6.3.tgz",
-      "integrity": "sha512-WMXwxhvzDeA/J+9jz1i8ZKGmbw/n+s988EiUvRI4egM+eTn31Hb5v10Re3slG3/qxntkBt2/6GkQVDGu6Bwyhw==",
+      "version": "29.6.4",
+      "resolved": "https://registry.npmjs.org/jest-resolve/-/jest-resolve-29.6.4.tgz",
+      "integrity": "sha512-fPRq+0vcxsuGlG0O3gyoqGTAxasagOxEuyoxHeyxaZbc9QNek0AmJWSkhjlMG+mTsj+8knc/mWb3fXlRNVih7Q==",
       "dev": true,
       "dependencies": {
         "chalk": "^4.0.0",
         "graceful-fs": "^4.2.9",
-        "jest-haste-map": "^29.6.3",
+        "jest-haste-map": "^29.6.4",
         "jest-pnp-resolver": "^1.2.2",
         "jest-util": "^29.6.3",
         "jest-validate": "^29.6.3",
@@ -6171,43 +6181,43 @@
       }
     },
     "node_modules/jest-resolve-dependencies": {
-      "version": "29.6.3",
-      "resolved": "https://registry.npmjs.org/jest-resolve-dependencies/-/jest-resolve-dependencies-29.6.3.tgz",
-      "integrity": "sha512-iah5nhSPTwtUV7yzpTc9xGg8gP3Ch2VNsuFMsKoCkNCrQSbFtx5KRPemmPJ32AUhTSDqJXB6djPN6zAaUGV53g==",
+      "version": "29.6.4",
+      "resolved": "https://registry.npmjs.org/jest-resolve-dependencies/-/jest-resolve-dependencies-29.6.4.tgz",
+      "integrity": "sha512-7+6eAmr1ZBF3vOAJVsfLj1QdqeXG+WYhidfLHBRZqGN24MFRIiKG20ItpLw2qRAsW/D2ZUUmCNf6irUr/v6KHA==",
       "dev": true,
       "dependencies": {
         "jest-regex-util": "^29.6.3",
-        "jest-snapshot": "^29.6.3"
+        "jest-snapshot": "^29.6.4"
       },
       "engines": {
         "node": "^14.15.0 || ^16.10.0 || >=18.0.0"
       }
     },
     "node_modules/jest-runner": {
-      "version": "29.6.3",
-      "resolved": "https://registry.npmjs.org/jest-runner/-/jest-runner-29.6.3.tgz",
-      "integrity": "sha512-E4zsMhQnjhirFPhDTJgoLMWUrVCDij/KGzWlbslDHGuO8Hl2pVUfOiygMzVZtZq+BzmlqwEr7LYmW+WFLlmX8w==",
+      "version": "29.6.4",
+      "resolved": "https://registry.npmjs.org/jest-runner/-/jest-runner-29.6.4.tgz",
+      "integrity": "sha512-SDaLrMmtVlQYDuG0iSPYLycG8P9jLI+fRm8AF/xPKhYDB2g6xDWjXBrR5M8gEWsK6KVFlebpZ4QsrxdyIX1Jaw==",
       "dev": true,
       "dependencies": {
-        "@jest/console": "^29.6.3",
-        "@jest/environment": "^29.6.3",
-        "@jest/test-result": "^29.6.3",
-        "@jest/transform": "^29.6.3",
+        "@jest/console": "^29.6.4",
+        "@jest/environment": "^29.6.4",
+        "@jest/test-result": "^29.6.4",
+        "@jest/transform": "^29.6.4",
         "@jest/types": "^29.6.3",
         "@types/node": "*",
         "chalk": "^4.0.0",
         "emittery": "^0.13.1",
         "graceful-fs": "^4.2.9",
         "jest-docblock": "^29.6.3",
-        "jest-environment-node": "^29.6.3",
-        "jest-haste-map": "^29.6.3",
+        "jest-environment-node": "^29.6.4",
+        "jest-haste-map": "^29.6.4",
         "jest-leak-detector": "^29.6.3",
         "jest-message-util": "^29.6.3",
-        "jest-resolve": "^29.6.3",
-        "jest-runtime": "^29.6.3",
+        "jest-resolve": "^29.6.4",
+        "jest-runtime": "^29.6.4",
         "jest-util": "^29.6.3",
-        "jest-watcher": "^29.6.3",
-        "jest-worker": "^29.6.3",
+        "jest-watcher": "^29.6.4",
+        "jest-worker": "^29.6.4",
         "p-limit": "^3.1.0",
         "source-map-support": "0.5.13"
       },
@@ -6226,17 +6236,17 @@
       }
     },
     "node_modules/jest-runtime": {
-      "version": "29.6.3",
-      "resolved": "https://registry.npmjs.org/jest-runtime/-/jest-runtime-29.6.3.tgz",
-      "integrity": "sha512-VM0Z3a9xaqizGpEKwCOIhImkrINYzxgwk8oQAvrmAiXX8LNrJrRjyva30RkuRY0ETAotHLlUcd2moviCA1hgsQ==",
+      "version": "29.6.4",
+      "resolved": "https://registry.npmjs.org/jest-runtime/-/jest-runtime-29.6.4.tgz",
+      "integrity": "sha512-s/QxMBLvmwLdchKEjcLfwzP7h+jsHvNEtxGP5P+Fl1FMaJX2jMiIqe4rJw4tFprzCwuSvVUo9bn0uj4gNRXsbA==",
       "dev": true,
       "dependencies": {
-        "@jest/environment": "^29.6.3",
-        "@jest/fake-timers": "^29.6.3",
-        "@jest/globals": "^29.6.3",
+        "@jest/environment": "^29.6.4",
+        "@jest/fake-timers": "^29.6.4",
+        "@jest/globals": "^29.6.4",
         "@jest/source-map": "^29.6.3",
-        "@jest/test-result": "^29.6.3",
-        "@jest/transform": "^29.6.3",
+        "@jest/test-result": "^29.6.4",
+        "@jest/transform": "^29.6.4",
         "@jest/types": "^29.6.3",
         "@types/node": "*",
         "chalk": "^4.0.0",
@@ -6244,12 +6254,12 @@
         "collect-v8-coverage": "^1.0.0",
         "glob": "^7.1.3",
         "graceful-fs": "^4.2.9",
-        "jest-haste-map": "^29.6.3",
+        "jest-haste-map": "^29.6.4",
         "jest-message-util": "^29.6.3",
         "jest-mock": "^29.6.3",
         "jest-regex-util": "^29.6.3",
-        "jest-resolve": "^29.6.3",
-        "jest-snapshot": "^29.6.3",
+        "jest-resolve": "^29.6.4",
+        "jest-snapshot": "^29.6.4",
         "jest-util": "^29.6.3",
         "slash": "^3.0.0",
         "strip-bom": "^4.0.0"
@@ -6259,9 +6269,9 @@
       }
     },
     "node_modules/jest-snapshot": {
-      "version": "29.6.3",
-      "resolved": "https://registry.npmjs.org/jest-snapshot/-/jest-snapshot-29.6.3.tgz",
-      "integrity": "sha512-66Iu7H1ojiveQMGFnKecHIZPPPBjZwfQEnF6wxqpxGf57sV3YSUtAb5/sTKM5TPa3OndyxZp1wxHFbmgVhc53w==",
+      "version": "29.6.4",
+      "resolved": "https://registry.npmjs.org/jest-snapshot/-/jest-snapshot-29.6.4.tgz",
+      "integrity": "sha512-VC1N8ED7+4uboUKGIDsbvNAZb6LakgIPgAF4RSpF13dN6YaMokfRqO+BaqK4zIh6X3JffgwbzuGqDEjHm/MrvA==",
       "dev": true,
       "dependencies": {
         "@babel/core": "^7.11.6",
@@ -6269,16 +6279,16 @@
         "@babel/plugin-syntax-jsx": "^7.7.2",
         "@babel/plugin-syntax-typescript": "^7.7.2",
         "@babel/types": "^7.3.3",
-        "@jest/expect-utils": "^29.6.3",
-        "@jest/transform": "^29.6.3",
+        "@jest/expect-utils": "^29.6.4",
+        "@jest/transform": "^29.6.4",
         "@jest/types": "^29.6.3",
         "babel-preset-current-node-syntax": "^1.0.0",
         "chalk": "^4.0.0",
-        "expect": "^29.6.3",
+        "expect": "^29.6.4",
         "graceful-fs": "^4.2.9",
-        "jest-diff": "^29.6.3",
+        "jest-diff": "^29.6.4",
         "jest-get-type": "^29.6.3",
-        "jest-matcher-utils": "^29.6.3",
+        "jest-matcher-utils": "^29.6.4",
         "jest-message-util": "^29.6.3",
         "jest-util": "^29.6.3",
         "natural-compare": "^1.4.0",
@@ -6336,12 +6346,12 @@
       }
     },
     "node_modules/jest-watcher": {
-      "version": "29.6.3",
-      "resolved": "https://registry.npmjs.org/jest-watcher/-/jest-watcher-29.6.3.tgz",
-      "integrity": "sha512-NgpFjZ2U2MKusjidbi4Oiu7tfs+nrgdIxIEVROvH1cFmOei9Uj25lwkMsakqLnH/s0nEcvxO1ck77FiRlcnpZg==",
+      "version": "29.6.4",
+      "resolved": "https://registry.npmjs.org/jest-watcher/-/jest-watcher-29.6.4.tgz",
+      "integrity": "sha512-oqUWvx6+On04ShsT00Ir9T4/FvBeEh2M9PTubgITPxDa739p4hoQweWPRGyYeaojgT0xTpZKF0Y/rSY1UgMxvQ==",
       "dev": true,
       "dependencies": {
-        "@jest/test-result": "^29.6.3",
+        "@jest/test-result": "^29.6.4",
         "@jest/types": "^29.6.3",
         "@types/node": "*",
         "ansi-escapes": "^4.2.1",
@@ -6355,9 +6365,9 @@
       }
     },
     "node_modules/jest-worker": {
-      "version": "29.6.3",
-      "resolved": "https://registry.npmjs.org/jest-worker/-/jest-worker-29.6.3.tgz",
-      "integrity": "sha512-wacANXecZ/GbQakpf2CClrqrlwsYYDSXFd4fIGdL+dXpM2GWoJ+6bhQ7vR3TKi3+gkSfBkjy1/khH/WrYS4Q6g==",
+      "version": "29.6.4",
+      "resolved": "https://registry.npmjs.org/jest-worker/-/jest-worker-29.6.4.tgz",
+      "integrity": "sha512-6dpvFV4WjcWbDVGgHTWo/aupl8/LbBx2NSKfiwqf79xC/yeJjKHT1+StcKy/2KTmW16hE68ccKVOtXf+WZGz7Q==",
       "dev": true,
       "dependencies": {
         "@types/node": "*",
@@ -6737,9 +6747,9 @@
       }
     },
     "node_modules/normalize-package-data/node_modules/semver": {
-      "version": "5.7.1",
-      "resolved": "https://registry.npmjs.org/semver/-/semver-5.7.1.tgz",
-      "integrity": "sha512-sauaDf/PZdVgrLTNYHRtpXa1iRiKcaebiKQ1BJdpQlWH2lCvexQdX55snPFyK7QzpudqbCI0qXFfOasHdyNDGQ==",
+      "version": "5.7.2",
+      "resolved": "https://registry.npmjs.org/semver/-/semver-5.7.2.tgz",
+      "integrity": "sha512-cBznnQ9KjJqU67B52RMC65CMarK2600WFnbkcaiwWq3xy/5haFJlshgnpjovMVJ+Hff49d8GEn0b87C5pDQ10g==",
       "dev": true,
       "bin": {
         "semver": "bin/semver"
@@ -7293,9 +7303,9 @@
       }
     },
     "node_modules/pure-rand": {
-      "version": "6.0.2",
-      "resolved": "https://registry.npmjs.org/pure-rand/-/pure-rand-6.0.2.tgz",
-      "integrity": "sha512-6Yg0ekpKICSjPswYOuC5sku/TSWaRYlA0qsXqJgM/d/4pLPHPuTxK7Nbf7jFKzAeedUhR8C7K9Uv63FBsSo8xQ==",
+      "version": "6.0.3",
+      "resolved": "https://registry.npmjs.org/pure-rand/-/pure-rand-6.0.3.tgz",
+      "integrity": "sha512-KddyFewCsO0j3+np81IQ+SweXLDnDQTs5s67BOnrYmYe/yNmUhttQyGsYzy8yUnoljGAQ9sl38YB4vH8ur7Y+w==",
       "dev": true,
       "funding": [
         {
@@ -7845,9 +7855,9 @@
       }
     },
     "node_modules/semver-truncate/node_modules/semver": {
-      "version": "6.3.0",
-      "resolved": "https://registry.npmjs.org/semver/-/semver-6.3.0.tgz",
-      "integrity": "sha512-b39TBaTSfV6yBrapU89p5fKekE2m/NwnDocOVruQFS1/veMgdzuPcnOM34M6CwxW8jH/lxEa5rBoDeUwu5HHTw==",
+      "version": "6.3.1",
+      "resolved": "https://registry.npmjs.org/semver/-/semver-6.3.1.tgz",
+      "integrity": "sha512-BR7VvDCVHO+q2xBEWskxS6DJE1qRnb7DxzUrogb71CWoSficBxYsiAGd+Kl0mmq/MprG9yArRkyrQxTO6XjMzA==",
       "bin": {
         "semver": "bin/semver.js"
       }
@@ -8035,9 +8045,12 @@
       }
     },
     "node_modules/string-comparison": {
-      "version": "1.1.0",
-      "resolved": "https://registry.npmjs.org/string-comparison/-/string-comparison-1.1.0.tgz",
-      "integrity": "sha512-9its9Hn37UNw6HlHFH0CGaTkkCWSCFtI3J5qLbuJqKAfbgEc0Ix+rFWfky47TcLlr5GvTSAqbGzHzQndZ7QaSQ=="
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/string-comparison/-/string-comparison-1.2.0.tgz",
+      "integrity": "sha512-Gk7kK438mY/EpZ9iSL02yNCH+k05d2ktwBF6u4RAYzg4ilbp+VICHaui42ArDv63weIl+bZuyXTRYYhI76d+jA==",
+      "engines": {
+        "node": "^16.0.0 || >=18.0.0"
+      }
     },
     "node_modules/string-length": {
       "version": "4.0.2",
@@ -8685,9 +8698,9 @@
       }
     },
     "node_modules/typescript": {
-      "version": "5.1.6",
-      "resolved": "https://registry.npmjs.org/typescript/-/typescript-5.1.6.tgz",
-      "integrity": "sha512-zaWCozRZ6DLEWAWFrVDz1H6FVXzUSfTy5FUMWsQlU8Ym5JP9eO4xkTIROFCQvhQf61z6O/G6ugw3SgAnvvm+HA==",
+      "version": "5.2.2",
+      "resolved": "https://registry.npmjs.org/typescript/-/typescript-5.2.2.tgz",
+      "integrity": "sha512-mI4WrpHsbCIcwT9cF4FZvr80QUeKvsUsUvKDoR+X/7XHQH98xYD8YHZg7ANtz2GtZt/CBq2QJ0thkGJMHfqc1w==",
       "bin": {
         "tsc": "bin/tsc",
         "tsserver": "bin/tsserver"
@@ -9051,9 +9064,9 @@
           "dev": true
         },
         "semver": {
-          "version": "6.3.0",
-          "resolved": "https://registry.npmjs.org/semver/-/semver-6.3.0.tgz",
-          "integrity": "sha512-b39TBaTSfV6yBrapU89p5fKekE2m/NwnDocOVruQFS1/veMgdzuPcnOM34M6CwxW8jH/lxEa5rBoDeUwu5HHTw==",
+          "version": "6.3.1",
+          "resolved": "https://registry.npmjs.org/semver/-/semver-6.3.1.tgz",
+          "integrity": "sha512-BR7VvDCVHO+q2xBEWskxS6DJE1qRnb7DxzUrogb71CWoSficBxYsiAGd+Kl0mmq/MprG9yArRkyrQxTO6XjMzA==",
           "dev": true
         }
       }
@@ -9101,9 +9114,9 @@
       },
       "dependencies": {
         "semver": {
-          "version": "6.3.0",
-          "resolved": "https://registry.npmjs.org/semver/-/semver-6.3.0.tgz",
-          "integrity": "sha512-b39TBaTSfV6yBrapU89p5fKekE2m/NwnDocOVruQFS1/veMgdzuPcnOM34M6CwxW8jH/lxEa5rBoDeUwu5HHTw==",
+          "version": "6.3.1",
+          "resolved": "https://registry.npmjs.org/semver/-/semver-6.3.1.tgz",
+          "integrity": "sha512-BR7VvDCVHO+q2xBEWskxS6DJE1qRnb7DxzUrogb71CWoSficBxYsiAGd+Kl0mmq/MprG9yArRkyrQxTO6XjMzA==",
           "dev": true
         }
       }
@@ -9632,9 +9645,9 @@
       "dev": true
     },
     "@jest/console": {
-      "version": "29.6.3",
-      "resolved": "https://registry.npmjs.org/@jest/console/-/console-29.6.3.tgz",
-      "integrity": "sha512-ukZbHAdDH4ktZIOKvWs1juAXhiVAdvCyM8zv4S/7Ii3vJSDvMW5k+wOVGMQmHLHUFw3Ko63ZQNy7NI6PSlsD5w==",
+      "version": "29.6.4",
+      "resolved": "https://registry.npmjs.org/@jest/console/-/console-29.6.4.tgz",
+      "integrity": "sha512-wNK6gC0Ha9QeEPSkeJedQuTQqxZYnDPuDcDhVuVatRvMkL4D0VTvFVZj+Yuh6caG2aOfzkUZ36KtCmLNtR02hw==",
       "dev": true,
       "requires": {
         "@jest/types": "^29.6.3",
@@ -9646,15 +9659,15 @@
       }
     },
     "@jest/core": {
-      "version": "29.6.3",
-      "resolved": "https://registry.npmjs.org/@jest/core/-/core-29.6.3.tgz",
-      "integrity": "sha512-skV1XrfNxfagmjRUrk2FyN5/2YwIzdWVVBa/orUfbLvQUANXxERq2pTvY0I+FinWHjDKB2HRmpveUiph4X0TJw==",
+      "version": "29.6.4",
+      "resolved": "https://registry.npmjs.org/@jest/core/-/core-29.6.4.tgz",
+      "integrity": "sha512-U/vq5ccNTSVgYH7mHnodHmCffGWHJnz/E1BEWlLuK5pM4FZmGfBn/nrJGLjUsSmyx3otCeqc1T31F4y08AMDLg==",
       "dev": true,
       "requires": {
-        "@jest/console": "^29.6.3",
-        "@jest/reporters": "^29.6.3",
-        "@jest/test-result": "^29.6.3",
-        "@jest/transform": "^29.6.3",
+        "@jest/console": "^29.6.4",
+        "@jest/reporters": "^29.6.4",
+        "@jest/test-result": "^29.6.4",
+        "@jest/transform": "^29.6.4",
         "@jest/types": "^29.6.3",
         "@types/node": "*",
         "ansi-escapes": "^4.2.1",
@@ -9663,18 +9676,18 @@
         "exit": "^0.1.2",
         "graceful-fs": "^4.2.9",
         "jest-changed-files": "^29.6.3",
-        "jest-config": "^29.6.3",
-        "jest-haste-map": "^29.6.3",
+        "jest-config": "^29.6.4",
+        "jest-haste-map": "^29.6.4",
         "jest-message-util": "^29.6.3",
         "jest-regex-util": "^29.6.3",
-        "jest-resolve": "^29.6.3",
-        "jest-resolve-dependencies": "^29.6.3",
-        "jest-runner": "^29.6.3",
-        "jest-runtime": "^29.6.3",
-        "jest-snapshot": "^29.6.3",
+        "jest-resolve": "^29.6.4",
+        "jest-resolve-dependencies": "^29.6.4",
+        "jest-runner": "^29.6.4",
+        "jest-runtime": "^29.6.4",
+        "jest-snapshot": "^29.6.4",
         "jest-util": "^29.6.3",
         "jest-validate": "^29.6.3",
-        "jest-watcher": "^29.6.3",
+        "jest-watcher": "^29.6.4",
         "micromatch": "^4.0.4",
         "pretty-format": "^29.6.3",
         "slash": "^3.0.0",
@@ -9682,40 +9695,40 @@
       }
     },
     "@jest/environment": {
-      "version": "29.6.3",
-      "resolved": "https://registry.npmjs.org/@jest/environment/-/environment-29.6.3.tgz",
-      "integrity": "sha512-u/u3cCztYCfgBiGHsamqP5x+XvucftOGPbf5RJQxfpeC1y4AL8pCjKvPDA3oCmdhZYPgk5AE0VOD/flweR69WA==",
+      "version": "29.6.4",
+      "resolved": "https://registry.npmjs.org/@jest/environment/-/environment-29.6.4.tgz",
+      "integrity": "sha512-sQ0SULEjA1XUTHmkBRl7A1dyITM9yb1yb3ZNKPX3KlTd6IG7mWUe3e2yfExtC2Zz1Q+mMckOLHmL/qLiuQJrBQ==",
       "dev": true,
       "requires": {
-        "@jest/fake-timers": "^29.6.3",
+        "@jest/fake-timers": "^29.6.4",
         "@jest/types": "^29.6.3",
         "@types/node": "*",
         "jest-mock": "^29.6.3"
       }
     },
     "@jest/expect": {
-      "version": "29.6.3",
-      "resolved": "https://registry.npmjs.org/@jest/expect/-/expect-29.6.3.tgz",
-      "integrity": "sha512-Ic08XbI2jlg6rECy+CGwk/8NDa6VE7UmIG6++9OTPAMnQmNGY28hu69Nf629CWv6T7YMODLbONxDFKdmQeI9FA==",
+      "version": "29.6.4",
+      "resolved": "https://registry.npmjs.org/@jest/expect/-/expect-29.6.4.tgz",
+      "integrity": "sha512-Warhsa7d23+3X5bLbrbYvaehcgX5TLYhI03JKoedTiI8uJU4IhqYBWF7OSSgUyz4IgLpUYPkK0AehA5/fRclAA==",
       "dev": true,
       "requires": {
-        "expect": "^29.6.3",
-        "jest-snapshot": "^29.6.3"
+        "expect": "^29.6.4",
+        "jest-snapshot": "^29.6.4"
       }
     },
     "@jest/expect-utils": {
-      "version": "29.6.3",
-      "resolved": "https://registry.npmjs.org/@jest/expect-utils/-/expect-utils-29.6.3.tgz",
-      "integrity": "sha512-nvOEW4YoqRKD9HBJ9OJ6przvIvP9qilp5nAn1462P5ZlL/MM9SgPEZFyjTGPfs7QkocdUsJa6KjHhyRn4ueItA==",
+      "version": "29.6.4",
+      "resolved": "https://registry.npmjs.org/@jest/expect-utils/-/expect-utils-29.6.4.tgz",
+      "integrity": "sha512-FEhkJhqtvBwgSpiTrocquJCdXPsyvNKcl/n7A3u7X4pVoF4bswm11c9d4AV+kfq2Gpv/mM8x7E7DsRvH+djkrg==",
       "dev": true,
       "requires": {
         "jest-get-type": "^29.6.3"
       }
     },
     "@jest/fake-timers": {
-      "version": "29.6.3",
-      "resolved": "https://registry.npmjs.org/@jest/fake-timers/-/fake-timers-29.6.3.tgz",
-      "integrity": "sha512-pa1wmqvbj6eX0nMvOM2VDAWvJOI5A/Mk3l8O7n7EsAh71sMZblaKO9iT4GjIj0LwwK3CP/Jp1ypEV0x3m89RvA==",
+      "version": "29.6.4",
+      "resolved": "https://registry.npmjs.org/@jest/fake-timers/-/fake-timers-29.6.4.tgz",
+      "integrity": "sha512-6UkCwzoBK60edXIIWb0/KWkuj7R7Qq91vVInOe3De6DSpaEiqjKcJw4F7XUet24Wupahj9J6PlR09JqJ5ySDHw==",
       "dev": true,
       "requires": {
         "@jest/types": "^29.6.3",
@@ -9727,27 +9740,27 @@
       }
     },
     "@jest/globals": {
-      "version": "29.6.3",
-      "resolved": "https://registry.npmjs.org/@jest/globals/-/globals-29.6.3.tgz",
-      "integrity": "sha512-RB+uI+CZMHntzlnOPlll5x/jgRff3LEPl/td/jzMXiIgR0iIhKq9qm1HLU+EC52NuoVy/1swit/sDGjVn4bc6A==",
+      "version": "29.6.4",
+      "resolved": "https://registry.npmjs.org/@jest/globals/-/globals-29.6.4.tgz",
+      "integrity": "sha512-wVIn5bdtjlChhXAzVXavcY/3PEjf4VqM174BM3eGL5kMxLiZD5CLnbmkEyA1Dwh9q8XjP6E8RwjBsY/iCWrWsA==",
       "dev": true,
       "requires": {
-        "@jest/environment": "^29.6.3",
-        "@jest/expect": "^29.6.3",
+        "@jest/environment": "^29.6.4",
+        "@jest/expect": "^29.6.4",
         "@jest/types": "^29.6.3",
         "jest-mock": "^29.6.3"
       }
     },
     "@jest/reporters": {
-      "version": "29.6.3",
-      "resolved": "https://registry.npmjs.org/@jest/reporters/-/reporters-29.6.3.tgz",
-      "integrity": "sha512-kGz59zMi0GkVjD2CJeYWG9k6cvj7eBqt9aDAqo2rcCLRTYlvQ62Gu/n+tOmJMBHGjzeijjuCENjzTyYBgrtLUw==",
+      "version": "29.6.4",
+      "resolved": "https://registry.npmjs.org/@jest/reporters/-/reporters-29.6.4.tgz",
+      "integrity": "sha512-sxUjWxm7QdchdrD3NfWKrL8FBsortZeibSJv4XLjESOOjSUOkjQcb0ZHJwfhEGIvBvTluTzfG2yZWZhkrXJu8g==",
       "dev": true,
       "requires": {
         "@bcoe/v8-coverage": "^0.2.3",
-        "@jest/console": "^29.6.3",
-        "@jest/test-result": "^29.6.3",
-        "@jest/transform": "^29.6.3",
+        "@jest/console": "^29.6.4",
+        "@jest/test-result": "^29.6.4",
+        "@jest/transform": "^29.6.4",
         "@jest/types": "^29.6.3",
         "@jridgewell/trace-mapping": "^0.3.18",
         "@types/node": "*",
@@ -9763,7 +9776,7 @@
         "istanbul-reports": "^3.1.3",
         "jest-message-util": "^29.6.3",
         "jest-util": "^29.6.3",
-        "jest-worker": "^29.6.3",
+        "jest-worker": "^29.6.4",
         "slash": "^3.0.0",
         "string-length": "^4.0.1",
         "strip-ansi": "^6.0.0",
@@ -9806,33 +9819,33 @@
       }
     },
     "@jest/test-result": {
-      "version": "29.6.3",
-      "resolved": "https://registry.npmjs.org/@jest/test-result/-/test-result-29.6.3.tgz",
-      "integrity": "sha512-k7ZZaNvOSMBHPZYiy0kuiaFoyansR5QnTwDux1EjK3kD5iWpRVyJIJ0RAIV39SThafchuW59vra7F8mdy5Hfgw==",
+      "version": "29.6.4",
+      "resolved": "https://registry.npmjs.org/@jest/test-result/-/test-result-29.6.4.tgz",
+      "integrity": "sha512-uQ1C0AUEN90/dsyEirgMLlouROgSY+Wc/JanVVk0OiUKa5UFh7sJpMEM3aoUBAz2BRNvUJ8j3d294WFuRxSyOQ==",
       "dev": true,
       "requires": {
-        "@jest/console": "^29.6.3",
+        "@jest/console": "^29.6.4",
         "@jest/types": "^29.6.3",
         "@types/istanbul-lib-coverage": "^2.0.0",
         "collect-v8-coverage": "^1.0.0"
       }
     },
     "@jest/test-sequencer": {
-      "version": "29.6.3",
-      "resolved": "https://registry.npmjs.org/@jest/test-sequencer/-/test-sequencer-29.6.3.tgz",
-      "integrity": "sha512-/SmijaAU2TY9ComFGIYa6Z+fmKqQMnqs2Nmwb0P/Z/tROdZ7M0iruES1EaaU9PBf8o9uED5xzaJ3YPFEIcDgAg==",
+      "version": "29.6.4",
+      "resolved": "https://registry.npmjs.org/@jest/test-sequencer/-/test-sequencer-29.6.4.tgz",
+      "integrity": "sha512-E84M6LbpcRq3fT4ckfKs9ryVanwkaIB0Ws9bw3/yP4seRLg/VaCZ/LgW0MCq5wwk4/iP/qnilD41aj2fsw2RMg==",
       "dev": true,
       "requires": {
-        "@jest/test-result": "^29.6.3",
+        "@jest/test-result": "^29.6.4",
         "graceful-fs": "^4.2.9",
-        "jest-haste-map": "^29.6.3",
+        "jest-haste-map": "^29.6.4",
         "slash": "^3.0.0"
       }
     },
     "@jest/transform": {
-      "version": "29.6.3",
-      "resolved": "https://registry.npmjs.org/@jest/transform/-/transform-29.6.3.tgz",
-      "integrity": "sha512-dPIc3DsvMZ/S8ut4L2ViCj265mKO0owB0wfzBv2oGzL9pQ+iRvJewHqLBmsGb7XFb5UotWIEtvY5A/lnylaIoQ==",
+      "version": "29.6.4",
+      "resolved": "https://registry.npmjs.org/@jest/transform/-/transform-29.6.4.tgz",
+      "integrity": "sha512-8thgRSiXUqtr/pPGY/OsyHuMjGyhVnWrFAwoxmIemlBuiMyU1WFs0tXoNxzcr4A4uErs/ABre76SGmrr5ab/AA==",
       "dev": true,
       "requires": {
         "@babel/core": "^7.11.6",
@@ -9843,7 +9856,7 @@
         "convert-source-map": "^2.0.0",
         "fast-json-stable-stringify": "^2.1.0",
         "graceful-fs": "^4.2.9",
-        "jest-haste-map": "^29.6.3",
+        "jest-haste-map": "^29.6.4",
         "jest-regex-util": "^29.6.3",
         "jest-util": "^29.6.3",
         "micromatch": "^4.0.4",
@@ -10141,6 +10154,16 @@
         "socket.io-client": "4.6.2"
       },
       "dependencies": {
+        "axios": {
+          "version": "1.4.0",
+          "resolved": "https://registry.npmjs.org/axios/-/axios-1.4.0.tgz",
+          "integrity": "sha512-S4XCWMEmzvo64T9GfvQDOXgYRDJ/wsSZc7Jvdgx5u1sd0JwsuPLqb3SYmusag+edF6ziyMensPVqLTSc1PiSEA==",
+          "requires": {
+            "follow-redirects": "^1.15.0",
+            "form-data": "^4.0.0",
+            "proxy-from-env": "^1.1.0"
+          }
+        },
         "engine.io-client": {
           "version": "6.4.0",
           "resolved": "https://registry.npmjs.org/engine.io-client/-/engine.io-client-6.4.0.tgz",
@@ -10861,9 +10884,9 @@
       "dev": true
     },
     "axios": {
-      "version": "1.4.0",
-      "resolved": "https://registry.npmjs.org/axios/-/axios-1.4.0.tgz",
-      "integrity": "sha512-S4XCWMEmzvo64T9GfvQDOXgYRDJ/wsSZc7Jvdgx5u1sd0JwsuPLqb3SYmusag+edF6ziyMensPVqLTSc1PiSEA==",
+      "version": "1.5.0",
+      "resolved": "https://registry.npmjs.org/axios/-/axios-1.5.0.tgz",
+      "integrity": "sha512-D4DdjDo5CY50Qms0qGQTTw6Q44jl7zRwY7bthds06pUGfChBCTcQs+N743eFWGEd6pRTMd6A+I87aWyFV5wiZQ==",
       "requires": {
         "follow-redirects": "^1.15.0",
         "form-data": "^4.0.0",
@@ -10871,12 +10894,12 @@
       }
     },
     "babel-jest": {
-      "version": "29.6.3",
-      "resolved": "https://registry.npmjs.org/babel-jest/-/babel-jest-29.6.3.tgz",
-      "integrity": "sha512-1Ne93zZZEy5XmTa4Q+W5+zxBrDpExX8E3iy+xJJ+24ewlfo/T3qHfQJCzi/MMVFmBQDNxtRR/Gfd2dwb/0yrQw==",
+      "version": "29.6.4",
+      "resolved": "https://registry.npmjs.org/babel-jest/-/babel-jest-29.6.4.tgz",
+      "integrity": "sha512-meLj23UlSLddj6PC+YTOFRgDAtjnZom8w/ACsrx0gtPtv5cJZk0A5Unk5bV4wixD7XaPCN1fQvpww8czkZURmw==",
       "dev": true,
       "requires": {
-        "@jest/transform": "^29.6.3",
+        "@jest/transform": "^29.6.4",
         "@types/babel__core": "^7.1.14",
         "babel-plugin-istanbul": "^6.1.1",
         "babel-preset-jest": "^29.6.3",
@@ -12167,14 +12190,14 @@
       "dev": true
     },
     "expect": {
-      "version": "29.6.3",
-      "resolved": "https://registry.npmjs.org/expect/-/expect-29.6.3.tgz",
-      "integrity": "sha512-x1vY4LlEMWUYVZQrFi4ZANXFwqYbJ/JNQspLVvzhW2BNY28aNcXMQH6imBbt+RBf5sVRTodYHXtSP/TLEU0Dxw==",
+      "version": "29.6.4",
+      "resolved": "https://registry.npmjs.org/expect/-/expect-29.6.4.tgz",
+      "integrity": "sha512-F2W2UyQ8XYyftHT57dtfg8Ue3X5qLgm2sSug0ivvLRH/VKNRL/pDxg/TH7zVzbQB0tu80clNFy6LU7OS/VSEKA==",
       "dev": true,
       "requires": {
-        "@jest/expect-utils": "^29.6.3",
+        "@jest/expect-utils": "^29.6.4",
         "jest-get-type": "^29.6.3",
-        "jest-matcher-utils": "^29.6.3",
+        "jest-matcher-utils": "^29.6.4",
         "jest-message-util": "^29.6.3",
         "jest-util": "^29.6.3"
       }
@@ -12957,9 +12980,9 @@
       },
       "dependencies": {
         "semver": {
-          "version": "6.3.0",
-          "resolved": "https://registry.npmjs.org/semver/-/semver-6.3.0.tgz",
-          "integrity": "sha512-b39TBaTSfV6yBrapU89p5fKekE2m/NwnDocOVruQFS1/veMgdzuPcnOM34M6CwxW8jH/lxEa5rBoDeUwu5HHTw==",
+          "version": "6.3.1",
+          "resolved": "https://registry.npmjs.org/semver/-/semver-6.3.1.tgz",
+          "integrity": "sha512-BR7VvDCVHO+q2xBEWskxS6DJE1qRnb7DxzUrogb71CWoSficBxYsiAGd+Kl0mmq/MprG9yArRkyrQxTO6XjMzA==",
           "dev": true
         }
       }
@@ -12997,15 +13020,15 @@
       }
     },
     "jest": {
-      "version": "29.6.3",
-      "resolved": "https://registry.npmjs.org/jest/-/jest-29.6.3.tgz",
-      "integrity": "sha512-alueLuoPCDNHFcFGmgETR4KpQ+0ff3qVaiJwxQM4B5sC0CvXcgg4PEi7xrDkxuItDmdz/FVc7SSit4KEu8GRvw==",
+      "version": "29.6.4",
+      "resolved": "https://registry.npmjs.org/jest/-/jest-29.6.4.tgz",
+      "integrity": "sha512-tEFhVQFF/bzoYV1YuGyzLPZ6vlPrdfvDmmAxudA1dLEuiztqg2Rkx20vkKY32xiDROcD2KXlgZ7Cu8RPeEHRKw==",
       "dev": true,
       "requires": {
-        "@jest/core": "^29.6.3",
+        "@jest/core": "^29.6.4",
         "@jest/types": "^29.6.3",
         "import-local": "^3.0.2",
-        "jest-cli": "^29.6.3"
+        "jest-cli": "^29.6.4"
       }
     },
     "jest-changed-files": {
@@ -13060,14 +13083,14 @@
       }
     },
     "jest-circus": {
-      "version": "29.6.3",
-      "resolved": "https://registry.npmjs.org/jest-circus/-/jest-circus-29.6.3.tgz",
-      "integrity": "sha512-p0R5YqZEMnOpHqHLWRSjm2z/0p6RNsrNE/GRRT3eli8QGOAozj6Ys/3Tv+Ej+IfltJoSPwcQ6/hOCRkNlxLLCw==",
+      "version": "29.6.4",
+      "resolved": "https://registry.npmjs.org/jest-circus/-/jest-circus-29.6.4.tgz",
+      "integrity": "sha512-YXNrRyntVUgDfZbjXWBMPslX1mQ8MrSG0oM/Y06j9EYubODIyHWP8hMUbjbZ19M3M+zamqEur7O80HODwACoJw==",
       "dev": true,
       "requires": {
-        "@jest/environment": "^29.6.3",
-        "@jest/expect": "^29.6.3",
-        "@jest/test-result": "^29.6.3",
+        "@jest/environment": "^29.6.4",
+        "@jest/expect": "^29.6.4",
+        "@jest/test-result": "^29.6.4",
         "@jest/types": "^29.6.3",
         "@types/node": "*",
         "chalk": "^4.0.0",
@@ -13075,10 +13098,10 @@
         "dedent": "^1.0.0",
         "is-generator-fn": "^2.0.0",
         "jest-each": "^29.6.3",
-        "jest-matcher-utils": "^29.6.3",
+        "jest-matcher-utils": "^29.6.4",
         "jest-message-util": "^29.6.3",
-        "jest-runtime": "^29.6.3",
-        "jest-snapshot": "^29.6.3",
+        "jest-runtime": "^29.6.4",
+        "jest-snapshot": "^29.6.4",
         "jest-util": "^29.6.3",
         "p-limit": "^3.1.0",
         "pretty-format": "^29.6.3",
@@ -13088,19 +13111,19 @@
       }
     },
     "jest-cli": {
-      "version": "29.6.3",
-      "resolved": "https://registry.npmjs.org/jest-cli/-/jest-cli-29.6.3.tgz",
-      "integrity": "sha512-KuPdXUPXQIf0t6DvmG8MV4QyhcjR1a6ruKl3YL7aGn/AQ8JkROwFkWzEpDIpt11Qy188dHbRm8WjwMsV/4nmnQ==",
+      "version": "29.6.4",
+      "resolved": "https://registry.npmjs.org/jest-cli/-/jest-cli-29.6.4.tgz",
+      "integrity": "sha512-+uMCQ7oizMmh8ZwRfZzKIEszFY9ksjjEQnTEMTaL7fYiL3Kw4XhqT9bYh+A4DQKUb67hZn2KbtEnDuHvcgK4pQ==",
       "dev": true,
       "requires": {
-        "@jest/core": "^29.6.3",
-        "@jest/test-result": "^29.6.3",
+        "@jest/core": "^29.6.4",
+        "@jest/test-result": "^29.6.4",
         "@jest/types": "^29.6.3",
         "chalk": "^4.0.0",
         "exit": "^0.1.2",
         "graceful-fs": "^4.2.9",
         "import-local": "^3.0.2",
-        "jest-config": "^29.6.3",
+        "jest-config": "^29.6.4",
         "jest-util": "^29.6.3",
         "jest-validate": "^29.6.3",
         "prompts": "^2.0.1",
@@ -13108,26 +13131,26 @@
       }
     },
     "jest-config": {
-      "version": "29.6.3",
-      "resolved": "https://registry.npmjs.org/jest-config/-/jest-config-29.6.3.tgz",
-      "integrity": "sha512-nb9bOq2aEqogbyL4F9mLkAeQGAgNt7Uz6U59YtQDIxFPiL7Ejgq0YIrp78oyEHD6H4CIV/k7mFrK7eFDzUJ69w==",
+      "version": "29.6.4",
+      "resolved": "https://registry.npmjs.org/jest-config/-/jest-config-29.6.4.tgz",
+      "integrity": "sha512-JWohr3i9m2cVpBumQFv2akMEnFEPVOh+9L2xIBJhJ0zOaci2ZXuKJj0tgMKQCBZAKA09H049IR4HVS/43Qb19A==",
       "dev": true,
       "requires": {
         "@babel/core": "^7.11.6",
-        "@jest/test-sequencer": "^29.6.3",
+        "@jest/test-sequencer": "^29.6.4",
         "@jest/types": "^29.6.3",
-        "babel-jest": "^29.6.3",
+        "babel-jest": "^29.6.4",
         "chalk": "^4.0.0",
         "ci-info": "^3.2.0",
         "deepmerge": "^4.2.2",
         "glob": "^7.1.3",
         "graceful-fs": "^4.2.9",
-        "jest-circus": "^29.6.3",
-        "jest-environment-node": "^29.6.3",
+        "jest-circus": "^29.6.4",
+        "jest-environment-node": "^29.6.4",
         "jest-get-type": "^29.6.3",
         "jest-regex-util": "^29.6.3",
-        "jest-resolve": "^29.6.3",
-        "jest-runner": "^29.6.3",
+        "jest-resolve": "^29.6.4",
+        "jest-runner": "^29.6.4",
         "jest-util": "^29.6.3",
         "jest-validate": "^29.6.3",
         "micromatch": "^4.0.4",
@@ -13138,9 +13161,9 @@
       }
     },
     "jest-diff": {
-      "version": "29.6.3",
-      "resolved": "https://registry.npmjs.org/jest-diff/-/jest-diff-29.6.3.tgz",
-      "integrity": "sha512-3sw+AdWnwH9sSNohMRKA7JiYUJSRr/WS6+sEFfBuhxU5V5GlEVKfvUn8JuMHE0wqKowemR1C2aHy8VtXbaV8dQ==",
+      "version": "29.6.4",
+      "resolved": "https://registry.npmjs.org/jest-diff/-/jest-diff-29.6.4.tgz",
+      "integrity": "sha512-9F48UxR9e4XOEZvoUXEHSWY4qC4zERJaOfrbBg9JpbJOO43R1vN76REt/aMGZoY6GD5g84nnJiBIVlscegefpw==",
       "dev": true,
       "requires": {
         "chalk": "^4.0.0",
@@ -13172,13 +13195,13 @@
       }
     },
     "jest-environment-node": {
-      "version": "29.6.3",
-      "resolved": "https://registry.npmjs.org/jest-environment-node/-/jest-environment-node-29.6.3.tgz",
-      "integrity": "sha512-PKl7upfPJXMYbWpD+60o4HP86KvFO2c9dZ+Zr6wUzsG5xcPx/65o3ArNgHW5M0RFvLYdW4/aieR4JSooD0a2ew==",
+      "version": "29.6.4",
+      "resolved": "https://registry.npmjs.org/jest-environment-node/-/jest-environment-node-29.6.4.tgz",
+      "integrity": "sha512-i7SbpH2dEIFGNmxGCpSc2w9cA4qVD+wfvg2ZnfQ7XVrKL0NA5uDVBIiGH8SR4F0dKEv/0qI5r+aDomDf04DpEQ==",
       "dev": true,
       "requires": {
-        "@jest/environment": "^29.6.3",
-        "@jest/fake-timers": "^29.6.3",
+        "@jest/environment": "^29.6.4",
+        "@jest/fake-timers": "^29.6.4",
         "@jest/types": "^29.6.3",
         "@types/node": "*",
         "jest-mock": "^29.6.3",
@@ -13192,9 +13215,9 @@
       "dev": true
     },
     "jest-haste-map": {
-      "version": "29.6.3",
-      "resolved": "https://registry.npmjs.org/jest-haste-map/-/jest-haste-map-29.6.3.tgz",
-      "integrity": "sha512-GecR5YavfjkhOytEFHAeI6aWWG3f/cOKNB1YJvj/B76xAmeVjy4zJUYobGF030cRmKaO1FBw3V8CZZ6KVh9ZSw==",
+      "version": "29.6.4",
+      "resolved": "https://registry.npmjs.org/jest-haste-map/-/jest-haste-map-29.6.4.tgz",
+      "integrity": "sha512-12Ad+VNTDHxKf7k+M65sviyynRoZYuL1/GTuhEVb8RYsNSNln71nANRb/faSyWvx0j+gHcivChXHIoMJrGYjog==",
       "dev": true,
       "requires": {
         "@jest/types": "^29.6.3",
@@ -13206,7 +13229,7 @@
         "graceful-fs": "^4.2.9",
         "jest-regex-util": "^29.6.3",
         "jest-util": "^29.6.3",
-        "jest-worker": "^29.6.3",
+        "jest-worker": "^29.6.4",
         "micromatch": "^4.0.4",
         "walker": "^1.0.8"
       }
@@ -13222,13 +13245,13 @@
       }
     },
     "jest-matcher-utils": {
-      "version": "29.6.3",
-      "resolved": "https://registry.npmjs.org/jest-matcher-utils/-/jest-matcher-utils-29.6.3.tgz",
-      "integrity": "sha512-6ZrMYINZdwduSt5Xu18/n49O1IgXdjsfG7NEZaQws9k69eTKWKcVbJBw/MZsjOZe2sSyJFmuzh8042XWwl54Zg==",
+      "version": "29.6.4",
+      "resolved": "https://registry.npmjs.org/jest-matcher-utils/-/jest-matcher-utils-29.6.4.tgz",
+      "integrity": "sha512-KSzwyzGvK4HcfnserYqJHYi7sZVqdREJ9DMPAKVbS98JsIAvumihaNUbjrWw0St7p9IY7A9UskCW5MYlGmBQFQ==",
       "dev": true,
       "requires": {
         "chalk": "^4.0.0",
-        "jest-diff": "^29.6.3",
+        "jest-diff": "^29.6.4",
         "jest-get-type": "^29.6.3",
         "pretty-format": "^29.6.3"
       }
@@ -13275,14 +13298,14 @@
       "dev": true
     },
     "jest-resolve": {
-      "version": "29.6.3",
-      "resolved": "https://registry.npmjs.org/jest-resolve/-/jest-resolve-29.6.3.tgz",
-      "integrity": "sha512-WMXwxhvzDeA/J+9jz1i8ZKGmbw/n+s988EiUvRI4egM+eTn31Hb5v10Re3slG3/qxntkBt2/6GkQVDGu6Bwyhw==",
+      "version": "29.6.4",
+      "resolved": "https://registry.npmjs.org/jest-resolve/-/jest-resolve-29.6.4.tgz",
+      "integrity": "sha512-fPRq+0vcxsuGlG0O3gyoqGTAxasagOxEuyoxHeyxaZbc9QNek0AmJWSkhjlMG+mTsj+8knc/mWb3fXlRNVih7Q==",
       "dev": true,
       "requires": {
         "chalk": "^4.0.0",
         "graceful-fs": "^4.2.9",
-        "jest-haste-map": "^29.6.3",
+        "jest-haste-map": "^29.6.4",
         "jest-pnp-resolver": "^1.2.2",
         "jest-util": "^29.6.3",
         "jest-validate": "^29.6.3",
@@ -13292,40 +13315,40 @@
       }
     },
     "jest-resolve-dependencies": {
-      "version": "29.6.3",
-      "resolved": "https://registry.npmjs.org/jest-resolve-dependencies/-/jest-resolve-dependencies-29.6.3.tgz",
-      "integrity": "sha512-iah5nhSPTwtUV7yzpTc9xGg8gP3Ch2VNsuFMsKoCkNCrQSbFtx5KRPemmPJ32AUhTSDqJXB6djPN6zAaUGV53g==",
+      "version": "29.6.4",
+      "resolved": "https://registry.npmjs.org/jest-resolve-dependencies/-/jest-resolve-dependencies-29.6.4.tgz",
+      "integrity": "sha512-7+6eAmr1ZBF3vOAJVsfLj1QdqeXG+WYhidfLHBRZqGN24MFRIiKG20ItpLw2qRAsW/D2ZUUmCNf6irUr/v6KHA==",
       "dev": true,
       "requires": {
         "jest-regex-util": "^29.6.3",
-        "jest-snapshot": "^29.6.3"
+        "jest-snapshot": "^29.6.4"
       }
     },
     "jest-runner": {
-      "version": "29.6.3",
-      "resolved": "https://registry.npmjs.org/jest-runner/-/jest-runner-29.6.3.tgz",
-      "integrity": "sha512-E4zsMhQnjhirFPhDTJgoLMWUrVCDij/KGzWlbslDHGuO8Hl2pVUfOiygMzVZtZq+BzmlqwEr7LYmW+WFLlmX8w==",
+      "version": "29.6.4",
+      "resolved": "https://registry.npmjs.org/jest-runner/-/jest-runner-29.6.4.tgz",
+      "integrity": "sha512-SDaLrMmtVlQYDuG0iSPYLycG8P9jLI+fRm8AF/xPKhYDB2g6xDWjXBrR5M8gEWsK6KVFlebpZ4QsrxdyIX1Jaw==",
       "dev": true,
       "requires": {
-        "@jest/console": "^29.6.3",
-        "@jest/environment": "^29.6.3",
-        "@jest/test-result": "^29.6.3",
-        "@jest/transform": "^29.6.3",
+        "@jest/console": "^29.6.4",
+        "@jest/environment": "^29.6.4",
+        "@jest/test-result": "^29.6.4",
+        "@jest/transform": "^29.6.4",
         "@jest/types": "^29.6.3",
         "@types/node": "*",
         "chalk": "^4.0.0",
         "emittery": "^0.13.1",
         "graceful-fs": "^4.2.9",
         "jest-docblock": "^29.6.3",
-        "jest-environment-node": "^29.6.3",
-        "jest-haste-map": "^29.6.3",
+        "jest-environment-node": "^29.6.4",
+        "jest-haste-map": "^29.6.4",
         "jest-leak-detector": "^29.6.3",
         "jest-message-util": "^29.6.3",
-        "jest-resolve": "^29.6.3",
-        "jest-runtime": "^29.6.3",
+        "jest-resolve": "^29.6.4",
+        "jest-runtime": "^29.6.4",
         "jest-util": "^29.6.3",
-        "jest-watcher": "^29.6.3",
-        "jest-worker": "^29.6.3",
+        "jest-watcher": "^29.6.4",
+        "jest-worker": "^29.6.4",
         "p-limit": "^3.1.0",
         "source-map-support": "0.5.13"
       },
@@ -13343,17 +13366,17 @@
       }
     },
     "jest-runtime": {
-      "version": "29.6.3",
-      "resolved": "https://registry.npmjs.org/jest-runtime/-/jest-runtime-29.6.3.tgz",
-      "integrity": "sha512-VM0Z3a9xaqizGpEKwCOIhImkrINYzxgwk8oQAvrmAiXX8LNrJrRjyva30RkuRY0ETAotHLlUcd2moviCA1hgsQ==",
+      "version": "29.6.4",
+      "resolved": "https://registry.npmjs.org/jest-runtime/-/jest-runtime-29.6.4.tgz",
+      "integrity": "sha512-s/QxMBLvmwLdchKEjcLfwzP7h+jsHvNEtxGP5P+Fl1FMaJX2jMiIqe4rJw4tFprzCwuSvVUo9bn0uj4gNRXsbA==",
       "dev": true,
       "requires": {
-        "@jest/environment": "^29.6.3",
-        "@jest/fake-timers": "^29.6.3",
-        "@jest/globals": "^29.6.3",
+        "@jest/environment": "^29.6.4",
+        "@jest/fake-timers": "^29.6.4",
+        "@jest/globals": "^29.6.4",
         "@jest/source-map": "^29.6.3",
-        "@jest/test-result": "^29.6.3",
-        "@jest/transform": "^29.6.3",
+        "@jest/test-result": "^29.6.4",
+        "@jest/transform": "^29.6.4",
         "@jest/types": "^29.6.3",
         "@types/node": "*",
         "chalk": "^4.0.0",
@@ -13361,21 +13384,21 @@
         "collect-v8-coverage": "^1.0.0",
         "glob": "^7.1.3",
         "graceful-fs": "^4.2.9",
-        "jest-haste-map": "^29.6.3",
+        "jest-haste-map": "^29.6.4",
         "jest-message-util": "^29.6.3",
         "jest-mock": "^29.6.3",
         "jest-regex-util": "^29.6.3",
-        "jest-resolve": "^29.6.3",
-        "jest-snapshot": "^29.6.3",
+        "jest-resolve": "^29.6.4",
+        "jest-snapshot": "^29.6.4",
         "jest-util": "^29.6.3",
         "slash": "^3.0.0",
         "strip-bom": "^4.0.0"
       }
     },
     "jest-snapshot": {
-      "version": "29.6.3",
-      "resolved": "https://registry.npmjs.org/jest-snapshot/-/jest-snapshot-29.6.3.tgz",
-      "integrity": "sha512-66Iu7H1ojiveQMGFnKecHIZPPPBjZwfQEnF6wxqpxGf57sV3YSUtAb5/sTKM5TPa3OndyxZp1wxHFbmgVhc53w==",
+      "version": "29.6.4",
+      "resolved": "https://registry.npmjs.org/jest-snapshot/-/jest-snapshot-29.6.4.tgz",
+      "integrity": "sha512-VC1N8ED7+4uboUKGIDsbvNAZb6LakgIPgAF4RSpF13dN6YaMokfRqO+BaqK4zIh6X3JffgwbzuGqDEjHm/MrvA==",
       "dev": true,
       "requires": {
         "@babel/core": "^7.11.6",
@@ -13383,16 +13406,16 @@
         "@babel/plugin-syntax-jsx": "^7.7.2",
         "@babel/plugin-syntax-typescript": "^7.7.2",
         "@babel/types": "^7.3.3",
-        "@jest/expect-utils": "^29.6.3",
-        "@jest/transform": "^29.6.3",
+        "@jest/expect-utils": "^29.6.4",
+        "@jest/transform": "^29.6.4",
         "@jest/types": "^29.6.3",
         "babel-preset-current-node-syntax": "^1.0.0",
         "chalk": "^4.0.0",
-        "expect": "^29.6.3",
+        "expect": "^29.6.4",
         "graceful-fs": "^4.2.9",
-        "jest-diff": "^29.6.3",
+        "jest-diff": "^29.6.4",
         "jest-get-type": "^29.6.3",
-        "jest-matcher-utils": "^29.6.3",
+        "jest-matcher-utils": "^29.6.4",
         "jest-message-util": "^29.6.3",
         "jest-util": "^29.6.3",
         "natural-compare": "^1.4.0",
@@ -13437,12 +13460,12 @@
       }
     },
     "jest-watcher": {
-      "version": "29.6.3",
-      "resolved": "https://registry.npmjs.org/jest-watcher/-/jest-watcher-29.6.3.tgz",
-      "integrity": "sha512-NgpFjZ2U2MKusjidbi4Oiu7tfs+nrgdIxIEVROvH1cFmOei9Uj25lwkMsakqLnH/s0nEcvxO1ck77FiRlcnpZg==",
+      "version": "29.6.4",
+      "resolved": "https://registry.npmjs.org/jest-watcher/-/jest-watcher-29.6.4.tgz",
+      "integrity": "sha512-oqUWvx6+On04ShsT00Ir9T4/FvBeEh2M9PTubgITPxDa739p4hoQweWPRGyYeaojgT0xTpZKF0Y/rSY1UgMxvQ==",
       "dev": true,
       "requires": {
-        "@jest/test-result": "^29.6.3",
+        "@jest/test-result": "^29.6.4",
         "@jest/types": "^29.6.3",
         "@types/node": "*",
         "ansi-escapes": "^4.2.1",
@@ -13453,9 +13476,9 @@
       }
     },
     "jest-worker": {
-      "version": "29.6.3",
-      "resolved": "https://registry.npmjs.org/jest-worker/-/jest-worker-29.6.3.tgz",
-      "integrity": "sha512-wacANXecZ/GbQakpf2CClrqrlwsYYDSXFd4fIGdL+dXpM2GWoJ+6bhQ7vR3TKi3+gkSfBkjy1/khH/WrYS4Q6g==",
+      "version": "29.6.4",
+      "resolved": "https://registry.npmjs.org/jest-worker/-/jest-worker-29.6.4.tgz",
+      "integrity": "sha512-6dpvFV4WjcWbDVGgHTWo/aupl8/LbBx2NSKfiwqf79xC/yeJjKHT1+StcKy/2KTmW16hE68ccKVOtXf+WZGz7Q==",
       "dev": true,
       "requires": {
         "@types/node": "*",
@@ -13738,9 +13761,9 @@
       },
       "dependencies": {
         "semver": {
-          "version": "5.7.1",
-          "resolved": "https://registry.npmjs.org/semver/-/semver-5.7.1.tgz",
-          "integrity": "sha512-sauaDf/PZdVgrLTNYHRtpXa1iRiKcaebiKQ1BJdpQlWH2lCvexQdX55snPFyK7QzpudqbCI0qXFfOasHdyNDGQ==",
+          "version": "5.7.2",
+          "resolved": "https://registry.npmjs.org/semver/-/semver-5.7.2.tgz",
+          "integrity": "sha512-cBznnQ9KjJqU67B52RMC65CMarK2600WFnbkcaiwWq3xy/5haFJlshgnpjovMVJ+Hff49d8GEn0b87C5pDQ10g==",
           "dev": true
         }
       }
@@ -14129,9 +14152,9 @@
       "dev": true
     },
     "pure-rand": {
-      "version": "6.0.2",
-      "resolved": "https://registry.npmjs.org/pure-rand/-/pure-rand-6.0.2.tgz",
-      "integrity": "sha512-6Yg0ekpKICSjPswYOuC5sku/TSWaRYlA0qsXqJgM/d/4pLPHPuTxK7Nbf7jFKzAeedUhR8C7K9Uv63FBsSo8xQ==",
+      "version": "6.0.3",
+      "resolved": "https://registry.npmjs.org/pure-rand/-/pure-rand-6.0.3.tgz",
+      "integrity": "sha512-KddyFewCsO0j3+np81IQ+SweXLDnDQTs5s67BOnrYmYe/yNmUhttQyGsYzy8yUnoljGAQ9sl38YB4vH8ur7Y+w==",
       "dev": true
     },
     "qs": {
@@ -14481,9 +14504,9 @@
       },
       "dependencies": {
         "semver": {
-          "version": "6.3.0",
-          "resolved": "https://registry.npmjs.org/semver/-/semver-6.3.0.tgz",
-          "integrity": "sha512-b39TBaTSfV6yBrapU89p5fKekE2m/NwnDocOVruQFS1/veMgdzuPcnOM34M6CwxW8jH/lxEa5rBoDeUwu5HHTw=="
+          "version": "6.3.1",
+          "resolved": "https://registry.npmjs.org/semver/-/semver-6.3.1.tgz",
+          "integrity": "sha512-BR7VvDCVHO+q2xBEWskxS6DJE1qRnb7DxzUrogb71CWoSficBxYsiAGd+Kl0mmq/MprG9yArRkyrQxTO6XjMzA=="
         }
       }
     },
@@ -14639,9 +14662,9 @@
       }
     },
     "string-comparison": {
-      "version": "1.1.0",
-      "resolved": "https://registry.npmjs.org/string-comparison/-/string-comparison-1.1.0.tgz",
-      "integrity": "sha512-9its9Hn37UNw6HlHFH0CGaTkkCWSCFtI3J5qLbuJqKAfbgEc0Ix+rFWfky47TcLlr5GvTSAqbGzHzQndZ7QaSQ=="
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/string-comparison/-/string-comparison-1.2.0.tgz",
+      "integrity": "sha512-Gk7kK438mY/EpZ9iSL02yNCH+k05d2ktwBF6u4RAYzg4ilbp+VICHaui42ArDv63weIl+bZuyXTRYYhI76d+jA=="
     },
     "string-length": {
       "version": "4.0.2",
@@ -15074,9 +15097,9 @@
       }
     },
     "typescript": {
-      "version": "5.1.6",
-      "resolved": "https://registry.npmjs.org/typescript/-/typescript-5.1.6.tgz",
-      "integrity": "sha512-zaWCozRZ6DLEWAWFrVDz1H6FVXzUSfTy5FUMWsQlU8Ym5JP9eO4xkTIROFCQvhQf61z6O/G6ugw3SgAnvvm+HA=="
+      "version": "5.2.2",
+      "resolved": "https://registry.npmjs.org/typescript/-/typescript-5.2.2.tgz",
+      "integrity": "sha512-mI4WrpHsbCIcwT9cF4FZvr80QUeKvsUsUvKDoR+X/7XHQH98xYD8YHZg7ANtz2GtZt/CBq2QJ0thkGJMHfqc1w=="
     },
     "unbox-primitive": {
       "version": "1.0.2",

--- a/package.json
+++ b/package.json
@@ -53,7 +53,7 @@
     "luxon": "^3.4.1",
     "prompts": "^2.4.2",
     "socket.io-client": "4.7.2",
-    "string-comparison": "^1.1.0"
+    "string-comparison": "^1.2.0"
   },
   "devDependencies": {
     "@types/async": "^3.2.20",
@@ -76,6 +76,6 @@
     "prettier": "3.0.2",
     "ts-jest": "^29.1.1",
     "ts-node-dev": "2.0.0",
-    "typescript": "^5.1.6"
+    "typescript": "^5.2.2"
   }
 }

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@tago-io/cli",
-  "version": "1.4.1",
+  "version": "1.5.0",
   "description": "TagoIO Application CLI Node.JS",
   "main": "./build/index.js",
   "repository": "tago-io/tagoio-cli",

--- a/src/commands/dashboard/copy-tab.ts
+++ b/src/commands/dashboard/copy-tab.ts
@@ -1,0 +1,150 @@
+import kleur from "kleur";
+import prompts from "prompts";
+
+import { Account } from "@tago-io/sdk";
+import { DashboardInfo } from "@tago-io/sdk/lib/types";
+
+import { getEnvironmentConfig } from "../../lib/config-file";
+import { errorHandler, infoMSG, successMSG } from "../../lib/messages";
+import { confirmPrompt } from "../../prompt/confirm";
+import { pickDashboardIDFromTagoIO } from "../../prompt/pick-dashboard-id-from-tagoio";
+
+interface IOptions {
+  to: string;
+  from: string;
+  environment: string;
+  amount: number;
+}
+
+interface DashboardTabs {
+  key: string;
+  value: string;
+  link: string;
+  hidden: boolean;
+}
+
+/**
+ *
+ * @param account
+ * @param dashID
+ * @param arrangement
+ * @param tabID
+ * @returns
+ */
+async function deleteWidgetsFromTab(account: Account, dashID: string, arrangement: DashboardInfo["arrangement"], tabID: string) {
+  if (!arrangement) {
+    return;
+  }
+
+  const myTabWidgets = arrangement.filter((x) => x.tab === tabID);
+  for (const item of myTabWidgets) {
+    await account.dashboards.widgets.delete(dashID, item.widget_id);
+  }
+
+  return arrangement.filter((x) => x.tab !== tabID);
+}
+
+/**
+ *
+ * @param account
+ * @param dashID
+ * @param arrangement
+ * @param tabID
+ * @param toTabID
+ * @returns
+ */
+async function copyWidgetsFromTab(account: Account, dashID: string, arrangement: DashboardInfo["arrangement"], tabID: string, toTabID: string) {
+  if (!arrangement) {
+    return;
+  }
+
+  const fromTabWidgets = arrangement.filter((x) => x.tab === tabID);
+  for (const item of fromTabWidgets) {
+    const widgetInfo = await account.dashboards.widgets.info(dashID, item.widget_id);
+    const { widget: newWidgetID } = await account.dashboards.widgets.create(dashID, widgetInfo);
+    arrangement.push({
+      widget_id: newWidgetID,
+      tab: toTabID,
+      x: item.x,
+      y: item.y,
+      width: item.width,
+      height: item.height,
+    });
+  }
+
+  return arrangement;
+}
+
+/**
+ *
+ * @param list
+ * @param message
+ * @returns
+ */
+async function pickTabFromDashboard(list: { title: string; value: string }[], message: string = "Which tab you want to pick?") {
+  const { id } = await prompts({
+    message,
+    name: "id",
+    type: "autocomplete",
+    choices: list,
+  });
+
+  return id as string;
+}
+
+/**
+ *
+ * @param dashID
+ * @param options
+ * @returns
+ */
+async function copyTabWidgets(dashID: string, options: IOptions) {
+  const config = getEnvironmentConfig(options.environment);
+  if (!config || !config.profileToken) {
+    errorHandler("Environment not found");
+    return;
+  }
+
+  const account = new Account({ token: config.profileToken, region: "usa-1" });
+  if (!dashID) {
+    dashID = await pickDashboardIDFromTagoIO(account);
+  }
+
+  const dashInfo = await account.dashboards.info(dashID);
+
+  if (!options.from || !options.to) {
+    let tabList = (dashInfo.tabs as DashboardTabs[]).map((x, i) => ({ title: `${i}. ${x.value} [${x.key}]`, value: x.key }));
+    if (!options.from) {
+      options.from = await pickTabFromDashboard(tabList, "Pick a tab to copy the data from:");
+    }
+
+    tabList = tabList.filter((x) => x.value !== options.from);
+    if (!options.to) {
+      options.to = await pickTabFromDashboard(tabList, "Pick a tab to copy the data to: ");
+    }
+  }
+
+  const { to, from } = options;
+  if (to === from) {
+    errorHandler("You can't copy data from and to the same tab");
+    return;
+  }
+
+  const toTabName = (dashInfo.tabs as DashboardTabs[]).find((x) => x.key === to)?.value as string;
+  const fromTabName = (dashInfo.tabs as DashboardTabs[]).find((x) => x.key === from)?.value as string;
+
+  infoMSG(`> Copying tab ${kleur.cyan(fromTabName)} to ${kleur.cyan(toTabName)}...`);
+  const yesNo = await confirmPrompt();
+  if (!yesNo) {
+    return;
+  }
+
+  let arrangement = await deleteWidgetsFromTab(account, dashID, dashInfo.arrangement, to);
+  arrangement = await copyWidgetsFromTab(account, dashID, arrangement, from, to);
+
+  await account.dashboards.edit(dashID, { arrangement });
+
+  successMSG(`> Tab ${fromTabName} [${kleur.cyan(from)}] copied to ${toTabName} [${kleur.cyan(to)}]`);
+}
+
+export { copyTabWidgets };

--- a/src/commands/dashboard/copy-tab.ts
+++ b/src/commands/dashboard/copy-tab.ts
@@ -115,12 +115,12 @@ async function copyTabWidgets(dashID: string, options: IOptions) {
   if (!options.from || !options.to) {
     let tabList = (dashInfo.tabs as DashboardTabs[]).map((x, i) => ({ title: `${i}. ${x.value} [${x.key}]`, value: x.key }));
     if (!options.from) {
-      options.from = await pickTabFromDashboard(tabList, "Pick a tab to copy the data from:");
+      options.from = await pickTabFromDashboard(tabList, "Pick a source tab to copy the data from:");
     }
 
     tabList = tabList.filter((x) => x.value !== options.from);
     if (!options.to) {
-      options.to = await pickTabFromDashboard(tabList, "Pick a tab to copy the data to: ");
+      options.to = await pickTabFromDashboard(tabList, "Pick a target tab to copy the data to: ");
     }
   }
 

--- a/src/commands/dashboard/index.ts
+++ b/src/commands/dashboard/index.ts
@@ -1,0 +1,37 @@
+import { Command } from "commander";
+
+import { copyTabWidgets } from "./copy-tab";
+
+// function handleNumber(value: any, _previous: any) {
+//   if (Number.isNaN(Number(value))) {
+//     throw `${value} is not a number`;
+//   }
+//   return Number(value);
+// }
+
+function dashboardCommands(program: Command) {
+  program.command("Devices Header");
+  program
+    .command("copy-tab")
+    .alias("inspect")
+    .description("copy a tab of a dashboard to another tab")
+    .argument("[dashboardID]", "ID of the dashboard")
+    .option("-from, --from [tabID]", "ID of the Tab to copy")
+    .option("-to, --to [tabID]", "ID of the Tab to paste")
+    .option("--env [environment]", "environment from config.js")
+    // .option("-g, --getOnly", "fiter logs to show GET content only")
+    .action(copyTabWidgets)
+    .addHelpText(
+      "after",
+      `
+      Running this command will completely erase the target tab and replace it with a copy of the source tab.
+
+Example:
+    $ tagoio copy-tab
+    $ tagoio copy-tab 62151835435d540010b768c4 -from 1688653060637 -to 2688653060638
+    $ tagoio copy-tab 62151835435d540010b768c4 --env dev
+       `
+    );
+}
+
+export { dashboardCommands };

--- a/src/commands/devices/copy-data.ts
+++ b/src/commands/devices/copy-data.ts
@@ -27,7 +27,7 @@ async function startCopy(deviceFrom: Device, deviceTo: Device, options: IOptions
     }
   }
 
-  successMSG(`> Data copy done. A total of ${total} registers were copied.`);
+  successMSG(`> Data transfer completed. A total of ${total} registers were copied.`);
 }
 
 async function copyDeviceData(options: IOptions) {
@@ -39,8 +39,8 @@ async function copyDeviceData(options: IOptions) {
 
   if (!options.from || !options.to) {
     const account = new Account({ token: config.profileToken, region: "usa-1" });
-    options.from = await pickDeviceIDFromTagoIO(account, "Pick a device to copy the data from:");
-    options.to = await pickDeviceIDFromTagoIO(account, "Pick a device to copy the data to: ");
+    options.from = await pickDeviceIDFromTagoIO(account, "Choose a device to copy the data from:");
+    options.to = await pickDeviceIDFromTagoIO(account, "Choose a device to copy the data to: ");
   }
 
   let deviceFrom: Device | undefined;

--- a/src/commands/devices/copy-data.ts
+++ b/src/commands/devices/copy-data.ts
@@ -1,0 +1,85 @@
+import { Account, Device, Utils } from "@tago-io/sdk";
+
+import { getEnvironmentConfig } from "../../lib/config-file";
+import { errorHandler, highlightMSG, infoMSG, successMSG } from "../../lib/messages";
+import { confirmPrompt } from "../../prompt/confirm";
+import { pickDeviceIDFromTagoIO } from "../../prompt/pick-device-id-from-tagoio";
+
+interface IOptions {
+  to: string;
+  from: string;
+  environment: string;
+  amount: number;
+}
+
+async function startCopy(deviceFrom: Device, deviceTo: Device, options: IOptions) {
+  const { amount } = options;
+
+  const dataStream = deviceFrom.getDataStreaming({}, { poolingRecordQty: 2000, poolingTime: 400, neverStop: false });
+
+  let total = 0;
+  for await (let data of dataStream) {
+    data = data.filter((x) => x.variable !== "payload");
+    total += data.length;
+    await deviceTo.sendData(data);
+    if (total >= amount) {
+      break;
+    }
+  }
+
+  successMSG(`> Data copy done. A total of ${total} registers were copied.`);
+}
+
+async function copyDeviceData(options: IOptions) {
+  const config = getEnvironmentConfig(options.environment);
+  if (!config || !config.profileToken) {
+    errorHandler("Environment not found");
+    return;
+  }
+
+  if (!options.from || !options.to) {
+    const account = new Account({ token: config.profileToken, region: "usa-1" });
+    options.from = await pickDeviceIDFromTagoIO(account, "Pick a device to copy the data from:");
+    options.to = await pickDeviceIDFromTagoIO(account, "Pick a device to copy the data to: ");
+  }
+
+  let deviceFrom: Device | undefined;
+  let deviceTo: Device | undefined;
+  if (options.from?.length === 24 || options.to?.length === 24) {
+    const account = new Account({ token: config.profileToken, region: "usa-1" });
+
+    if (options.from.length === 24) {
+      deviceFrom = await Utils.getDevice(account, options.from);
+    }
+
+    if (options.to.length === 24) {
+      deviceTo = await Utils.getDevice(account, options.to);
+    }
+  }
+
+  if (!deviceTo || !deviceFrom) {
+    errorHandler("Device not found");
+    return;
+  }
+
+  if (!deviceFrom) {
+    deviceFrom = new Device({ token: options.from });
+  }
+
+  if (!deviceTo) {
+    deviceTo = new Device({ token: options.to });
+  }
+
+  const deviceToInfo = await deviceTo.info();
+  const deviceFromInfo = await deviceFrom.info();
+
+  infoMSG(`> Copying tab ${highlightMSG(deviceFromInfo.name)} to ${highlightMSG(deviceToInfo.name)}...`);
+  const yesNo = await confirmPrompt();
+  if (!yesNo) {
+    return;
+  }
+
+  await startCopy(deviceFrom, deviceTo, options);
+}
+
+export { copyDeviceData };

--- a/src/commands/devices/index.ts
+++ b/src/commands/devices/index.ts
@@ -2,6 +2,7 @@ import { Command } from "commander";
 
 import { cmdRepeteableValue } from "../../lib/commander-repeatable";
 import { changeBucketType } from "./change-bucket-type";
+import { copyDeviceData } from "./copy-data";
 import { getDeviceData } from "./data-get";
 import { bkpDeviceData } from "./device-bkp";
 import { deviceInfo } from "./device-info";
@@ -146,6 +147,24 @@ Example:
      $ tagoio device-type
      $ tagoio device-type 62151835435d540010b768c4
      `
+    );
+
+  program
+    .command("device-copy")
+    .description(`copy data from one device to another`)
+    .option("-from, --from [token/id]", "token/id of the device where data will be copied from")
+    .option("-to, --to [token/id]", "token/id of the device where data will be copied to")
+    .option("-qty, --qty <number>", "amount of data to be copy", handleNumber, 10_000)
+    .option("-env, --environment [environment]", "environment from config.js")
+    .action(copyDeviceData)
+    .addHelpText(
+      "after",
+      `
+
+Example:
+   $ tagoio device-copy
+   $ tagoio device-copy --to 62151835435d540010b768c4 --from 78151835435d540010b768c4
+   `
     );
 }
 

--- a/src/commands/list-env.ts
+++ b/src/commands/list-env.ts
@@ -1,4 +1,5 @@
 import { Account } from "@tago-io/sdk";
+
 import { getConfigFile, writeToConfigFile } from "../lib/config-file";
 import { infoMSG } from "../lib/messages";
 import { readToken } from "../lib/token";
@@ -20,11 +21,20 @@ async function fixEnvironments(configFile: ReturnType<typeof getConfigFile>, env
     }
 
     const account = new Account({ token });
-    const profile = await account.profiles.info("current");
-    const accInfo = await account.info();
-    environment.id = profile.info.id;
-    environment.profileName = profile.info.name;
-    environment.email = accInfo.email;
+    const profile = await account.profiles.info("current").catch((error) => {
+      console.error(`Error getting profile info for ${env}: ${error.message}`);
+      return;
+    });
+
+    if (profile) {
+      const accInfo = await account.info();
+      environment.id = profile.info.id;
+      environment.profileName = profile.info.name;
+      environment.email = accInfo.email;
+    } else if (!environment.id && !environment.profileName) {
+      environment.id = "N/A";
+      environment.profileName = "N/A";
+    }
   }
 
   writeToConfigFile(configFile);

--- a/src/commands/profile/export/services/access-export.ts
+++ b/src/commands/profile/export/services/access-export.ts
@@ -1,4 +1,5 @@
 import { Account } from "@tago-io/sdk";
+
 import { replaceObj } from "../../../../lib/replace-obj";
 import { IExportHolder } from "../types";
 
@@ -17,7 +18,7 @@ async function accessExport(account: Account, import_account: Account, export_ho
 
     let { id: target_id } = import_list.find((access) => access.tags?.find((tag) => tag.key === "export_id" && tag.value == export_id)) || { id: null };
 
-    const new_access = replaceObj(access, { ...export_holder.devices, ...export_holder.dashboards });
+    const new_access = replaceObj(access, { ...export_holder.devices, ...export_holder.dashboards, ...export_holder.analysis });
     if (!target_id) {
       ({ am_id: target_id } = await import_account.accessManagement.create(new_access));
     } else {

--- a/src/commands/profile/export/services/run-buttons-export.ts
+++ b/src/commands/profile/export/services/run-buttons-export.ts
@@ -64,6 +64,12 @@ async function runButtonsExport(account: Account, import_account: Account, expor
     targetRunInfo.email_templates[template_name] = email_obj;
   }
 
+  // Custom Fields
+  // @ts-expect-error SDK doesn't have custom fields property yet
+  targetRunInfo.custom_fields = runInfo.custom_fields;
+
+  targetRunInfo.signin_buttons = runInfo.signin_buttons;
+
   // @ts-expect-error ignore error
   delete targetRunInfo.created_at;
 

--- a/src/commands/start-config.ts
+++ b/src/commands/start-config.ts
@@ -1,7 +1,7 @@
 import { readdirSync } from "fs";
 import kleur from "kleur";
 import prompts, { Choice } from "prompts";
-import { cosine } from "string-comparison";
+import stringComparison from "string-comparison";
 
 import { Account } from "@tago-io/sdk";
 import { AnalysisInfo } from "@tago-io/sdk/lib/types";
@@ -90,7 +90,9 @@ async function getAnalysisScripts(analysisList: IEnvironment["analysisList"], an
     .map((x) => ({ title: x }));
 
   for (const analysis of analysisList) {
-    files = files.sort((a, b) => (cosine.distance(analysis.name, a.title) > cosine.distance(analysis.name, b.title) ? 1 : -1));
+    files = files.sort((a, b) =>
+      stringComparison.cosine.distance(analysis.name, a.title) > stringComparison.cosine.distance(analysis.name, b.title) ? 1 : -1
+    );
 
     const editFile = files.find((x) => x.title === analysis.fileName);
     const { response } = await prompts({

--- a/src/index.ts
+++ b/src/index.ts
@@ -3,7 +3,9 @@ import { readFileSync } from "fs";
 import { Command } from "commander";
 import dotenv from "dotenv";
 import kleur from "kleur";
+
 import { analysisCommands } from "./commands/analysis";
+import { dashboardCommands } from "./commands/dashboard";
 import { deviceCommands } from "./commands/devices";
 import { listEnvironment } from "./commands/list-env";
 import { tagoLogin } from "./commands/login";
@@ -25,6 +27,7 @@ const defaultEnvironment = process.env.TAGOIO_DEFAULT || "";
 async function getAllCommands(program: Command) {
   analysisCommands(program);
   deviceCommands(program);
+  dashboardCommands(program);
   profileCommands(program, defaultEnvironment);
 }
 

--- a/src/lib/search-name.ts
+++ b/src/lib/search-name.ts
@@ -1,10 +1,10 @@
-import { cosine } from "string-comparison";
+import stringComparison from "string-comparison";
 
 function orderNames(key: string, names: string[]) {
   const similarity = Math.max(
     ...names.map((x) => {
       const argValue = x.toLowerCase().replace(".ts", "");
-      return cosine.similarity(key, argValue);
+      return stringComparison.cosine.similarity(key, argValue);
     })
   );
 

--- a/src/prompt/pick-dashboard-id-from-tagoio.ts
+++ b/src/prompt/pick-dashboard-id-from-tagoio.ts
@@ -2,7 +2,7 @@ import prompts from "prompts";
 
 import { Account } from "@tago-io/sdk";
 
-async function pickDashboardIDFromTagoIO(account: Account, message: string = "Which dashboard you want to pick?") {
+async function pickDashboardIDFromTagoIO(account: Account, message: string = "Which dashboard you want to choose?") {
   const deviceList = await account.dashboards.list({ amount: 100, fields: ["id", "label"] });
 
   const { id } = await prompts({

--- a/src/prompt/pick-dashboard-id-from-tagoio.ts
+++ b/src/prompt/pick-dashboard-id-from-tagoio.ts
@@ -1,0 +1,18 @@
+import prompts from "prompts";
+
+import { Account } from "@tago-io/sdk";
+
+async function pickDashboardIDFromTagoIO(account: Account, message: string = "Which dashboard you want to pick?") {
+  const deviceList = await account.dashboards.list({ amount: 100, fields: ["id", "label"] });
+
+  const { id } = await prompts({
+    message,
+    name: "id",
+    type: "autocomplete",
+    choices: deviceList.map((x) => ({ title: `${x.label} [${x.id}]`, value: x.id })),
+  });
+
+  return id as string;
+}
+
+export { pickDashboardIDFromTagoIO };

--- a/src/prompt/pick-device-id-from-tagoio.ts
+++ b/src/prompt/pick-device-id-from-tagoio.ts
@@ -1,11 +1,12 @@
-import { Account } from "@tago-io/sdk";
 import prompts from "prompts";
 
-async function pickDeviceIDFromTagoIO(account: Account) {
+import { Account } from "@tago-io/sdk";
+
+async function pickDeviceIDFromTagoIO(account: Account, message: string = "Which device you want to pick?") {
   const deviceList = await account.devices.list({ amount: 100, fields: ["id", "name"] });
 
   const { id } = await prompts({
-    message: "Which device you want to pick?",
+    message,
     name: "id",
     type: "autocomplete",
     choices: deviceList.map((x) => ({ title: x.name, value: x.id })),

--- a/src/prompt/pick-device-id-from-tagoio.ts
+++ b/src/prompt/pick-device-id-from-tagoio.ts
@@ -2,7 +2,7 @@ import prompts from "prompts";
 
 import { Account } from "@tago-io/sdk";
 
-async function pickDeviceIDFromTagoIO(account: Account, message: string = "Which device you want to pick?") {
+async function pickDeviceIDFromTagoIO(account: Account, message: string = "Which device you want to choose?") {
   const deviceList = await account.devices.list({ amount: 100, fields: ["id", "name"] });
 
   const { id } = await prompts({


### PR DESCRIPTION
Add new commands and fix the export for access policies on analysis.

Added:
- command copy-tab to duplicate tab in a dashboard
- command device-copy to copy the bucket from device to another

Fixed:
- Exporting access rules not replacing the analysis IDs
- Exporting Run Buttons not exporting Dynamic Values settings