### PR TITLE
Refactor resolveCLIPath function to handle both Windows and Linux paths

### DIFF
--- a/src/lib/config-file.ts
+++ b/src/lib/config-file.ts
@@ -26,9 +26,12 @@ interface IConfigFile {
 
 function resolveCLIPath(suffix: string) {
   let path = __dirname;
-  const pathSlices = path.split("/");
+  // Handle windows and linux paths
+  const pathSymbol = path.includes("\\") ? "\\" : "/";
+
+  const pathSlices = path.split(pathSymbol);
   const cliWordPosition = pathSlices.findIndex((x) => x.includes("cli")) + 1;
-  path = pathSlices.slice(0, cliWordPosition).join("/");
+  path = pathSlices.slice(0, cliWordPosition).join(pathSymbol);
   return join(path, suffix);
 }
 


### PR DESCRIPTION
This pull request refactors the resolveCLIPath function in the config-file.ts file to handle both Windows and Linux paths. Previously, the function only worked with Linux paths, but now it can handle paths with either forward slashes or backslashes. This improves the compatibility of the function across different operating systems.