### PR TITLE
feat/tagoio-deploy-url

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,7 +4,6 @@
 </p>
 
 # Table of Contents
-
 - [TagoIO Command Line Tools](#tagoio-command-line-tools)
 - [How to Install](#how-to-install)
 - [Command List](#command-list)
@@ -17,7 +16,6 @@
 For more information on the latest release notes, please visit the [Release Notes section](https://github.com/tago-io/tagoio-cli/releases)
 
 ## TagoIO Command Line Tools
-
 TagoIO Command Line Tools is a CLI tool that allows you to interact with TagoIO platform and manage your applications. You can use it to deploy, run, trigger, and debug your analysis, as well as to inspect, backup, and configure your devices. You can also export your applications from one profile to another.
 
 To use this tool, you need to install it globally with npm and also install the builder dependency. You also need to generate a tagoconfig.json file for your project and a .tago-lock file for your profile. You can work with multiple environments by using the init and set-env commands.
@@ -26,23 +24,24 @@ For more information about the commands and options of this tool, please refer t
 
 ![CLI Demo](./docs/images/tagoio_inspect.png)
 
+
 # How to Install
 
 Installing the TagoIO Command Line Tools is a straightforward process. Follow these steps to get started:
 
 1. **Preparation**: Ensure that Node.js and npm are installed on your machine. If not, refer to the [installation guide](^1^).
+   
 2. **CLI Tool Installation**: Open your terminal and run the following command to install the CLI tool globally:
    ```sh
    npm install -g @tago-io/cli
    ```
+   
 3. **Builder Dependency Installation**: Next, install the builder dependency using the command:
-
    ```sh
    npm install -g @tago-io/builder
    ```
 
 4. **Project Initialization**: Initialize your project by generating a `tagoconfig.json` file. Use the command below and follow the on-screen instructions to provide your credentials or profile-token (available in your TagoIO account):
-
    ```sh
    tagoio init
    ```
@@ -53,51 +52,48 @@ Installing the TagoIO Command Line Tools is a straightforward process. Follow th
    ```
 
 ## Command List
-
 List of commands of the CLI
 **Usage**:
-
 - tagoio [options] [command]
 
 **Options**:
-
-- -V, --version output the version number
-- -h, --help display help for command
+-  -V, --version                          output the version number
+-  -h, --help                             display help for command
 
 **Commands**:
 
-| Command                              | Description                                                          |
-| ------------------------------------ | -------------------------------------------------------------------- |
-| init [environment]                   | create/update the config file for analysis in your current folder    |
-| login [environment]                  | login to your account and store profile_token in the .tago/tago-lock |
-| set-env [environment]                | set your default environment from tagoconfig.ts                      |
-| list-env                             | list all your environment and show current default                   |
-|                                      |                                                                      |
-| **Analysis**                         |                                                                      |
-| deploy, analysis-deploy [name]       | deploy your analysis to TagoIO                                       |
-| run, analysis-run [name]             | run your TagoIO analysis from your machine.                          |
-| at, analysis-trigger [name]          | send a signal to trigger your analysis TagoIO                        |
-| ac, analysis-console [name]          | connect to your Analysis Console                                     |
-| ad, analysis-duplicate [ID]          | duplicate your Analysis                                              |
-| am, analysis-mode [name]             | change an analysis or group of analysis to run on tago/external      |
-|                                      |                                                                      |
-| **Devices**                          |                                                                      |
-| inspect, device-inspector [ID/Token] | connect to your Device Live Inspector                                |
-| info, device-info [ID/Token]         | get information about a device and it's configuration parameters     |
-| dl, device-list                      | get the list of devices                                              |
-| data [ID/Token]                      | get data from a device                                               |
-| bkp, device-backup [ID/Token]        | backup data from a Device. Store it on the TagoIO Cloud by default   |
-| device-type [ID/Token]               | change the bucket type to immutable or mutable                       |
-|                                      |
-| **Profiles**                         |                                                                      |
-| export, app-export                   | export an application from one profile to another                    |
+| Command | Description |
+| ---- | ---- |
+| init [environment] | create/update the config file for analysis in your current folder |
+| login [environment] | login to your account and store profile_token in the .tago/tago-lock |
+| set-env [environment] | set your default environment from tagoconfig.ts |
+| list-env | list all your environment and show current default |
+| | |
+| **Analysis** | |
+| deploy, analysis-deploy [name] | deploy your analysis to TagoIO |
+| run, analysis-run [name] | run your TagoIO analysis from your machine. |
+| at, analysis-trigger [name] | send a signal to trigger your analysis TagoIO |
+| ac, analysis-console [name] | connect to your Analysis Console |
+| ad, analysis-duplicate [ID] | duplicate your Analysis |
+| am, analysis-mode [name] | change an analysis or group of analysis to run on tago/external |
+| | |
+| **Devices** | |
+| inspect, device-inspector [ID/Token] | connect to your Device Live Inspector |
+| info, device-info [ID/Token] | get information about a device and it's configuration parameters |
+| dl, device-list  | get the list of devices |
+| data [ID/Token] | get data from a device |
+| bkp, device-backup [ID/Token] | backup data from a Device. Store it on the TagoIO Cloud by default |
+| device-type [ID/Token] | change the bucket type to immutable or mutable |
+| |
+| **Profiles** | |
+| export, app-export | export an application from one profile to another |
 
 ## Analysis Runner
-
 When writing up your analysis, make sure you have the following lines at end of the code:
 
 ```javascript
 Analysis.use(startAnalysis, { token: process.env.T_ANALYSIS_TOKEN });
+
 ```
 
 If you want to use the Debugger with -D, make sure you have a **.swcrc** file with sourceMaps activated. This repository contains a .swcrc.example file if you prefer to just copy to your folder.
@@ -107,7 +103,6 @@ If you want to use the Debugger with -D, make sure you have a **.swcrc** file wi
 Managing multiple environments is a breeze with the TagoIO CLI. This feature facilitates seamless alternation between different environments for deployment and analysis management. Here's how you can make the most of it:
 
 ### Creating a New Environment
-
 To set up a new environment, use the `tagoio init` command. This will guide you through the necessary steps to establish a fresh environment for your project. Here's how you can do it:
 
 ```sh
@@ -115,12 +110,12 @@ tagoio init
 ```
 
 ### Switching Between Environments
-
 If you are working with multiple environments, switching between them is essential. Use the `tagoio set-env` command to change your current environment effortlessly. Here's the command to use:
 
 ```sh
 tagoio set-env [environment_name]
 ```
+
 
 ## Credentials Storage
 
@@ -131,13 +126,13 @@ Securing your credentials is a critical aspect of working with the TagoIO CLI. T
 When you execute commands like `tagoio login` or `tagoio init`, the CLI securely stores your Profile-Token in the current folder accessed by your terminal. Here's a brief on these commands:
 
 1. **tagoio login**: This command allows you to log in to your account, storing the profile token in the process.
-
+   
    ```sh
    tagoio login
    ```
 
 2. **tagoio init**: This command initiates the creation of a new project, during which you will be prompted to enter your credentials, generating a Profile-Token.
-
+   
    ```sh
    tagoio init
    ```
@@ -147,7 +142,6 @@ When you execute commands like `tagoio login` or `tagoio init`, the CLI securely
 The stored Profile-Token is encrypted and saved in a file named `.tago-lock.{env}.lock`, ensuring the security of your sensitive information.
 
 ## tagoconfig.json
-
 The `tagoconfig.json` file serves as the central configuration file for your JavaScript or TypeScript project when working with the TagoIO CLI. This file contains vital information about your analysis, including their IDs and names. Here's how you can set up and utilize the `tagoconfig.json` file effectively:
 
 ### Creating the tagoconfig.json File
@@ -175,22 +169,23 @@ The `tagoconfig.json` file encapsulates information about your current project, 
 Having a `tagoconfig.json` file is essential for executing several commands, such as:
 
 - **tagoio deploy**: This command deploys your project to the TagoIO platform.
-
+  
   ```sh
   tagoio deploy
   ```
 
 - **tagoio trigger**: Use this command to trigger specific actions or events in your project.
-
+  
   ```sh
   tagoio trigger
   ```
 
 - **tagoio run**: This command allows you to run your project locally for testing and development.
-
+  
   ```sh
   tagoio run
   ```
+
 
 ## License
 

--- a/README.md
+++ b/README.md
@@ -152,9 +152,9 @@ To create a `tagoconfig.json` file, initiate your project using the `tagoio init
 tagoio init
 ```
 
-If you are using the TagoIO Deploy service, you can configure the URL:
+If you are using the TagoDeploy service, you can configure the URL:
 
-- To configure the URL for the TagoIO Deploy service, update the `tagoDeployUrl` field in the `tagoconfig.json` file with the URL of your server to utilize your API.
+- To configure the URL for the TagoDeploy service, update the `tagoDeployUrl` field in the `tagoconfig.json` file with the URL of your server to utilize your API.
 
 ### File Contents
 

--- a/README.md
+++ b/README.md
@@ -4,6 +4,7 @@
 </p>
 
 # Table of Contents
+
 - [TagoIO Command Line Tools](#tagoio-command-line-tools)
 - [How to Install](#how-to-install)
 - [Command List](#command-list)
@@ -16,6 +17,7 @@
 For more information on the latest release notes, please visit the [Release Notes section](https://github.com/tago-io/tagoio-cli/releases)
 
 ## TagoIO Command Line Tools
+
 TagoIO Command Line Tools is a CLI tool that allows you to interact with TagoIO platform and manage your applications. You can use it to deploy, run, trigger, and debug your analysis, as well as to inspect, backup, and configure your devices. You can also export your applications from one profile to another.
 
 To use this tool, you need to install it globally with npm and also install the builder dependency. You also need to generate a tagoconfig.json file for your project and a .tago-lock file for your profile. You can work with multiple environments by using the init and set-env commands.
@@ -24,24 +26,23 @@ For more information about the commands and options of this tool, please refer t
 
 ![CLI Demo](./docs/images/tagoio_inspect.png)
 
-
 # How to Install
 
 Installing the TagoIO Command Line Tools is a straightforward process. Follow these steps to get started:
 
 1. **Preparation**: Ensure that Node.js and npm are installed on your machine. If not, refer to the [installation guide](^1^).
-   
 2. **CLI Tool Installation**: Open your terminal and run the following command to install the CLI tool globally:
    ```sh
    npm install -g @tago-io/cli
    ```
-   
 3. **Builder Dependency Installation**: Next, install the builder dependency using the command:
+
    ```sh
    npm install -g @tago-io/builder
    ```
 
 4. **Project Initialization**: Initialize your project by generating a `tagoconfig.json` file. Use the command below and follow the on-screen instructions to provide your credentials or profile-token (available in your TagoIO account):
+
    ```sh
    tagoio init
    ```
@@ -52,48 +53,51 @@ Installing the TagoIO Command Line Tools is a straightforward process. Follow th
    ```
 
 ## Command List
+
 List of commands of the CLI
 **Usage**:
+
 - tagoio [options] [command]
 
 **Options**:
--  -V, --version                          output the version number
--  -h, --help                             display help for command
+
+- -V, --version output the version number
+- -h, --help display help for command
 
 **Commands**:
 
-| Command | Description |
-| ---- | ---- |
-| init [environment] | create/update the config file for analysis in your current folder |
-| login [environment] | login to your account and store profile_token in the .tago/tago-lock |
-| set-env [environment] | set your default environment from tagoconfig.ts |
-| list-env | list all your environment and show current default |
-| | |
-| **Analysis** | |
-| deploy, analysis-deploy [name] | deploy your analysis to TagoIO |
-| run, analysis-run [name] | run your TagoIO analysis from your machine. |
-| at, analysis-trigger [name] | send a signal to trigger your analysis TagoIO |
-| ac, analysis-console [name] | connect to your Analysis Console |
-| ad, analysis-duplicate [ID] | duplicate your Analysis |
-| am, analysis-mode [name] | change an analysis or group of analysis to run on tago/external |
-| | |
-| **Devices** | |
-| inspect, device-inspector [ID/Token] | connect to your Device Live Inspector |
-| info, device-info [ID/Token] | get information about a device and it's configuration parameters |
-| dl, device-list  | get the list of devices |
-| data [ID/Token] | get data from a device |
-| bkp, device-backup [ID/Token] | backup data from a Device. Store it on the TagoIO Cloud by default |
-| device-type [ID/Token] | change the bucket type to immutable or mutable |
-| |
-| **Profiles** | |
-| export, app-export | export an application from one profile to another |
+| Command                              | Description                                                          |
+| ------------------------------------ | -------------------------------------------------------------------- |
+| init [environment]                   | create/update the config file for analysis in your current folder    |
+| login [environment]                  | login to your account and store profile_token in the .tago/tago-lock |
+| set-env [environment]                | set your default environment from tagoconfig.ts                      |
+| list-env                             | list all your environment and show current default                   |
+|                                      |                                                                      |
+| **Analysis**                         |                                                                      |
+| deploy, analysis-deploy [name]       | deploy your analysis to TagoIO                                       |
+| run, analysis-run [name]             | run your TagoIO analysis from your machine.                          |
+| at, analysis-trigger [name]          | send a signal to trigger your analysis TagoIO                        |
+| ac, analysis-console [name]          | connect to your Analysis Console                                     |
+| ad, analysis-duplicate [ID]          | duplicate your Analysis                                              |
+| am, analysis-mode [name]             | change an analysis or group of analysis to run on tago/external      |
+|                                      |                                                                      |
+| **Devices**                          |                                                                      |
+| inspect, device-inspector [ID/Token] | connect to your Device Live Inspector                                |
+| info, device-info [ID/Token]         | get information about a device and it's configuration parameters     |
+| dl, device-list                      | get the list of devices                                              |
+| data [ID/Token]                      | get data from a device                                               |
+| bkp, device-backup [ID/Token]        | backup data from a Device. Store it on the TagoIO Cloud by default   |
+| device-type [ID/Token]               | change the bucket type to immutable or mutable                       |
+|                                      |
+| **Profiles**                         |                                                                      |
+| export, app-export                   | export an application from one profile to another                    |
 
 ## Analysis Runner
+
 When writing up your analysis, make sure you have the following lines at end of the code:
 
 ```javascript
 Analysis.use(startAnalysis, { token: process.env.T_ANALYSIS_TOKEN });
-
 ```
 
 If you want to use the Debugger with -D, make sure you have a **.swcrc** file with sourceMaps activated. This repository contains a .swcrc.example file if you prefer to just copy to your folder.
@@ -103,6 +107,7 @@ If you want to use the Debugger with -D, make sure you have a **.swcrc** file wi
 Managing multiple environments is a breeze with the TagoIO CLI. This feature facilitates seamless alternation between different environments for deployment and analysis management. Here's how you can make the most of it:
 
 ### Creating a New Environment
+
 To set up a new environment, use the `tagoio init` command. This will guide you through the necessary steps to establish a fresh environment for your project. Here's how you can do it:
 
 ```sh
@@ -110,12 +115,12 @@ tagoio init
 ```
 
 ### Switching Between Environments
+
 If you are working with multiple environments, switching between them is essential. Use the `tagoio set-env` command to change your current environment effortlessly. Here's the command to use:
 
 ```sh
 tagoio set-env [environment_name]
 ```
-
 
 ## Credentials Storage
 
@@ -126,13 +131,13 @@ Securing your credentials is a critical aspect of working with the TagoIO CLI. T
 When you execute commands like `tagoio login` or `tagoio init`, the CLI securely stores your Profile-Token in the current folder accessed by your terminal. Here's a brief on these commands:
 
 1. **tagoio login**: This command allows you to log in to your account, storing the profile token in the process.
-   
+
    ```sh
    tagoio login
    ```
 
 2. **tagoio init**: This command initiates the creation of a new project, during which you will be prompted to enter your credentials, generating a Profile-Token.
-   
+
    ```sh
    tagoio init
    ```
@@ -142,6 +147,7 @@ When you execute commands like `tagoio login` or `tagoio init`, the CLI securely
 The stored Profile-Token is encrypted and saved in a file named `.tago-lock.{env}.lock`, ensuring the security of your sensitive information.
 
 ## tagoconfig.json
+
 The `tagoconfig.json` file serves as the central configuration file for your JavaScript or TypeScript project when working with the TagoIO CLI. This file contains vital information about your analysis, including their IDs and names. Here's how you can set up and utilize the `tagoconfig.json` file effectively:
 
 ### Creating the tagoconfig.json File
@@ -152,6 +158,9 @@ To create a `tagoconfig.json` file, initiate your project using the `tagoio init
 tagoio init
 ```
 
+If you are using the TagoIO Deploy service, you can configure the URL:
+
+- To configure the URL for the TagoIO Deploy service, update the `tagoDeployUrl` field in the `tagoconfig.json` file with the URL of your server to utilize your API.
 
 ### File Contents
 
@@ -166,23 +175,22 @@ The `tagoconfig.json` file encapsulates information about your current project, 
 Having a `tagoconfig.json` file is essential for executing several commands, such as:
 
 - **tagoio deploy**: This command deploys your project to the TagoIO platform.
-  
+
   ```sh
   tagoio deploy
   ```
 
 - **tagoio trigger**: Use this command to trigger specific actions or events in your project.
-  
+
   ```sh
   tagoio trigger
   ```
 
 - **tagoio run**: This command allows you to run your project locally for testing and development.
-  
+
   ```sh
   tagoio run
   ```
-
 
 ## License
 

--- a/README.md
+++ b/README.md
@@ -152,9 +152,10 @@ To create a `tagoconfig.json` file, initiate your project using the `tagoio init
 tagoio init
 ```
 
-If you are using the TagoDeploy service, you can configure the URL:
+If you are using the TagoDeploy service, you can configure the URLs for both the API and SSE:
 
-- To configure the URL for the TagoDeploy service, update the `tagoDeployUrl` field in the `tagoconfig.json` file with the URL of your server to utilize your API.
+- To set the URL for the API in the TagoDeploy service, update the `tagoDeployUrl` field in the `tagoconfig.json` file with the URL of your server.
+- To set the URL for SSE in the TagoDeploy service, update the `tagoDeploySse` field in the `tagoconfig.json` file with the URL of your server.
 
 ### File Contents
 

--- a/docs/schema.json
+++ b/docs/schema.json
@@ -51,9 +51,14 @@
           "format": "uri-reference"
       },
       "tagoDeployUrl": {
-          "description": "URL to of the TagoIO deploy server",
+          "description": "URL to API for TagoDeploy server",
           "type": "string",
           "format": "uri-reference"
+      },
+      "tagoDeploySse": {
+        "description": "URL to SSE for TagoDeploy server",
+        "type": "string",
+        "format": "uri-reference"
       },
       "buildPath": {
           "description": "Path from the root of the project to the build folder",

--- a/docs/schema.json
+++ b/docs/schema.json
@@ -50,6 +50,11 @@
           "type": "string",
           "format": "uri-reference"
       },
+      "tagoDeployUrl": {
+          "description": "URL to of the TagoIO deploy server",
+          "type": "string",
+          "format": "uri-reference"
+      },
       "buildPath": {
           "description": "Path from the root of the project to the build folder",
           "type": "string",

--- a/src/commands/analysis/analysis-console.ts
+++ b/src/commands/analysis/analysis-console.ts
@@ -92,7 +92,7 @@ async function connectAnalysisConsole(scriptName: string | void, options: { envi
     return;
   }
 
-  const account = new Account({ token: config.profileToken, region: "usa-1" });
+  const account = new Account({ token: config.profileToken, region: !process.env.TAGOIO_API ? "usa-1" : "env" });
   const analysis_info = await account.analysis.info(scriptObj.id);
   if (!analysis_info) {
     errorHandler(`Analysis with ID: ${scriptObj.id} couldn't be found.`);

--- a/src/commands/analysis/analysis-set-mode.ts
+++ b/src/commands/analysis/analysis-set-mode.ts
@@ -67,7 +67,7 @@ async function analysisSetMode(userInputName: string | void, options: { environm
     return;
   }
 
-  const account = new Account({ token: config.profileToken, region: "usa-1" });
+  const account = new Account({ token: config.profileToken, region: !process.env.TAGOIO_API ? "usa-1" : "env" });
   const analysisFilterName = userInputName ? `*${userInputName}*` : undefined;
 
   // Get analysis list from TagoIO

--- a/src/commands/analysis/deploy.ts
+++ b/src/commands/analysis/deploy.ts
@@ -125,7 +125,7 @@ async function deployAnalysis(cmdScriptName: string, options: { environment: str
     return;
   }
 
-  const account = new Account({ token: config.profileToken, region: "usa-1" });
+  const account = new Account({ token: config.profileToken, region: !process.env.TAGOIO_API ? "usa-1" : "env" });
   for (const { id, fileName } of scriptList) {
     await buildScript(account, fileName, id, config);
   }

--- a/src/commands/analysis/run-analysis.ts
+++ b/src/commands/analysis/run-analysis.ts
@@ -74,7 +74,7 @@ async function runAnalysis(scriptName: string | undefined, options: { environmen
     return process.exit();
   }
 
-  const account = new Account({ token: config.profileToken, region: "usa-1" });
+  const account = new Account({ token: config.profileToken, region: !process.env.TAGOIO_API ? "usa-1" : "env" });
 
   let { token: analysisToken, run_on, name } = await account.analysis.info(scriptToRun.id);
   successMSG(`> Analysis found: ${highlightMSG(scriptToRun.fileName)} (${name}}) [${highlightMSG(analysisToken)}].`);

--- a/src/commands/analysis/trigger-analysis.ts
+++ b/src/commands/analysis/trigger-analysis.ts
@@ -24,7 +24,7 @@ async function triggerAnalysis(scriptName: string | void, options: { environment
     return;
   }
 
-  const account = new Account({ token: config.profileToken, region: "usa-1" });
+  const account = new Account({ token: config.profileToken, region: !process.env.TAGOIO_API ? "usa-1" : "env" });
   const analysisList = config.analysisList.filter((x) => x.fileName);
 
   let script: IEnvironment["analysisList"][0] | undefined;

--- a/src/commands/dashboard/copy-tab.ts
+++ b/src/commands/dashboard/copy-tab.ts
@@ -110,7 +110,7 @@ async function copyTabWidgets(dashID: string, options: IOptions) {
     return;
   }
 
-  const account = new Account({ token: config.profileToken, region: "usa-1" });
+  const account = new Account({ token: config.profileToken, region: !process.env.TAGOIO_API ? "usa-1" : "env" });
   if (!dashID) {
     dashID = await pickDashboardIDFromTagoIO(account);
   }

--- a/src/commands/devices/change-bucket-type.ts
+++ b/src/commands/devices/change-bucket-type.ts
@@ -16,7 +16,7 @@ interface BucketSettings {
 const coloredBucketType = (type: string) => (type === "mutable" ? kleur.green(type) : type === "legacy" ? kleur.red(type) : kleur.blue(type));
 
 async function convertDevice(deviceID: string, settings: BucketSettings, profileToken: string) {
-  const account = new Account({ token: profileToken, region: "usa-1" });
+  const account = new Account({ token: profileToken, region: !process.env.TAGOIO_API ? "usa-1" : "env" });
   const deviceInfo = await account.devices.info(deviceID);
   const bucketType = deviceInfo.type;
 
@@ -81,7 +81,7 @@ async function changeBucketType(id: string, options: { environment: string }) {
     errorHandler("Environment not found");
     return;
   }
-  const account = new Account({ token: config.profileToken, region: "usa-1" });
+  const account = new Account({ token: config.profileToken, region: !process.env.TAGOIO_API ? "usa-1" : "env" });
   const bucketList = id ? [id] : await chooseBucketsFromList(account);
   if (id) {
     const bucketInfo = await account.buckets.info(id);

--- a/src/commands/devices/copy-data.ts
+++ b/src/commands/devices/copy-data.ts
@@ -38,7 +38,7 @@ async function copyDeviceData(options: IOptions) {
   }
 
   if (!options.from || !options.to) {
-    const account = new Account({ token: config.profileToken, region: "usa-1" });
+    const account = new Account({ token: config.profileToken, region: !process.env.TAGOIO_API ? "usa-1" : "env" });
     options.from = await pickDeviceIDFromTagoIO(account, "Choose a device to copy the data from:");
     options.to = await pickDeviceIDFromTagoIO(account, "Choose a device to copy the data to: ");
   }
@@ -46,7 +46,7 @@ async function copyDeviceData(options: IOptions) {
   let deviceFrom: Device | undefined;
   let deviceTo: Device | undefined;
   if (options.from?.length === 24 || options.to?.length === 24) {
-    const account = new Account({ token: config.profileToken, region: "usa-1" });
+    const account = new Account({ token: config.profileToken, region: !process.env.TAGOIO_API ? "usa-1" : "env" });
 
     if (options.from.length === 24) {
       deviceFrom = await Utils.getDevice(account, options.from);

--- a/src/commands/devices/data-get.ts
+++ b/src/commands/devices/data-get.ts
@@ -89,7 +89,7 @@ async function getDeviceData(idOrToken: string, options: IOptions) {
     errorHandler("Environment not found");
     return;
   }
-  const account = new Account({ token: config.profileToken, region: "usa-1" });
+  const account = new Account({ token: config.profileToken, region: !process.env.TAGOIO_API ? "usa-1" : "env" });
   if (!idOrToken) {
     idOrToken = await pickDeviceIDFromTagoIO(account);
   }

--- a/src/commands/devices/data-post.ts
+++ b/src/commands/devices/data-post.ts
@@ -15,14 +15,14 @@ async function postDeviceData(idOrToken: string, options: IOptions) {
     return;
   }
 
-  const account = new Account({ token: config.profileToken, region: "usa-1" });
+  const account = new Account({ token: config.profileToken, region: !process.env.TAGOIO_API ? "usa-1" : "env" });
   if (!idOrToken) {
     idOrToken = await pickDeviceIDFromTagoIO(account);
   }
   const deviceInfo = await account.devices
     .info(idOrToken)
     .catch(() => {
-      const device = new Device({ token: idOrToken, region: "usa-1" });
+      const device = new Device({ token: idOrToken, region: !process.env.TAGOIO_API ? "usa-1" : "env" });
       return device.info();
     })
     .catch(errorHandler);

--- a/src/commands/devices/device-bkp.ts
+++ b/src/commands/devices/device-bkp.ts
@@ -111,7 +111,7 @@ async function bkpDeviceData(idOrToken: string, options: IOptions) {
     return;
   }
 
-  const account = new Account({ token: config.profileToken, region: "usa-1" });
+  const account = new Account({ token: config.profileToken, region: !process.env.TAGOIO_API ? "usa-1" : "env" });
   if (!idOrToken) {
     idOrToken = await pickDeviceIDFromTagoIO(account);
   }
@@ -119,7 +119,7 @@ async function bkpDeviceData(idOrToken: string, options: IOptions) {
   const deviceInfo = await account.devices
     .info(idOrToken)
     .catch(() => {
-      const device = new Device({ token: idOrToken, region: "usa-1" });
+      const device = new Device({ token: idOrToken, region: !process.env.TAGOIO_API ? "usa-1" : "env" });
       return device.info();
     })
     .catch(errorHandler);

--- a/src/commands/devices/device-info.ts
+++ b/src/commands/devices/device-info.ts
@@ -13,7 +13,7 @@ async function deviceInfo(idOrToken: string, options: { environment: string; raw
     return;
   }
 
-  const account = new Account({ token: config.profileToken, region: "usa-1" });
+  const account = new Account({ token: config.profileToken, region: !process.env.TAGOIO_API ? "usa-1" : "env" });
   if (!idOrToken) {
     idOrToken = await pickDeviceIDFromTagoIO(account);
   }

--- a/src/commands/devices/device-live-inspector.ts
+++ b/src/commands/devices/device-live-inspector.ts
@@ -104,14 +104,14 @@ async function inspectorConnection(deviceIdOrToken: string, options: IOptions) {
     return;
   }
 
-  const account = new Account({ token: config.profileToken, region: "usa-1" });
+  const account = new Account({ token: config.profileToken, region: !process.env.TAGOIO_API ? "usa-1" : "env" });
   if (!deviceIdOrToken) {
     deviceIdOrToken = await pickDeviceIDFromTagoIO(account);
   }
 
   let deviceInfo = await account.devices.info(deviceIdOrToken).catch(() => null);
   if (!deviceInfo) {
-    const device = new Device({ token: deviceIdOrToken, region: "usa-1" });
+    const device = new Device({ token: deviceIdOrToken, region: !process.env.TAGOIO_API ? "usa-1" : "env" });
     deviceInfo = await device
       .info()
       .then((r) => r as DeviceInfo)

--- a/src/commands/login.ts
+++ b/src/commands/login.ts
@@ -6,6 +6,29 @@ import { OTPType } from "@tago-io/sdk/lib/types";
 import { errorHandler, highlightMSG, successMSG } from "../lib/messages";
 import { writeToken } from "../lib/token";
 
+/**
+ * @description Set the TagoIO deploy URL.
+ */
+async function setTagoDeployUrl() {
+  const { tagoDeployUrl } = await prompts({
+    message: "Do you want to pass on the tagoDeploy URL?",
+    type: "confirm",
+    name: "tagoDeployUrl",
+  });
+  if (!tagoDeployUrl) {
+    return;
+  }
+
+  const { urlAPI } = await prompts({ type: "text", name: "urlAPI", message: "Set the URL for the API service: " });
+  if (urlAPI) {
+    process.env.TAGOIO_API = urlAPI;
+  }
+
+  console.info(process.env.TAGOIO_API);
+
+  return urlAPI;
+}
+
 function writeCustomToken(environment: string, token: string) {
   writeToken(token, environment);
   successMSG(`Token successfully written to the environment ${highlightMSG(environment)}.`);
@@ -15,6 +38,7 @@ interface LoginOptions {
   email?: string;
   password?: string;
   token?: string;
+  tagoDeployUrl?: string;
 }
 
 /**
@@ -56,7 +80,7 @@ async function loginWithEmailPassword(email: string, password: string) {
     try {
       const errorJSON = JSON.parse(error);
       if (errorJSON?.otp_enabled) {
-        return handleOTPLogin(errorJSON, { email, password, token: "" });
+        return handleOTPLogin(errorJSON, { email, password, token: "", tagoDeployUrl: "" });
       }
     } catch {
       // Ignore JSON parsing errors
@@ -67,6 +91,9 @@ async function loginWithEmailPassword(email: string, password: string) {
 }
 
 async function tagoLogin(environment: string, options: LoginOptions) {
+  const tagoDeployUrl = await setTagoDeployUrl();
+  options.tagoDeployUrl = tagoDeployUrl;
+
   if (options.token) {
     return writeCustomToken(environment, options.token);
   }

--- a/src/commands/login.ts
+++ b/src/commands/login.ts
@@ -50,7 +50,7 @@ interface LoginOptions {
  * @param {string} loginOptions.password - The user's password.
  * @returns {Promise<Object>} - The login result.
  */
-async function handleOTPLogin({ otp_autosend }: { otp_autosend: OTPType }, { email, password }: Required<LoginOptions>) {
+async function handleOTPLogin({ otp_autosend }: { otp_autosend: OTPType }, { email, password }: Required<Pick<LoginOptions, "email" | "password">>) {
   if (otp_autosend !== "authenticator") {
     await Account.requestLoginPINCode({ email, password }, otp_autosend).catch(errorHandler);
   }
@@ -80,7 +80,7 @@ async function loginWithEmailPassword(email: string, password: string) {
     try {
       const errorJSON = JSON.parse(error);
       if (errorJSON?.otp_enabled) {
-        return handleOTPLogin(errorJSON, { email, password, token: "", tagoDeployUrl: "" });
+        return handleOTPLogin(errorJSON, { email, password });
       }
     } catch {
       // Ignore JSON parsing errors

--- a/src/commands/profile/export/export-setup.ts
+++ b/src/commands/profile/export/export-setup.ts
@@ -124,7 +124,7 @@ async function setupExport(options: { setup: string }) {
     return;
   }
 
-  const account = new Account({ token: config.profileToken, region: "usa-1" });
+  const account = new Account({ token: config.profileToken, region: !process.env.TAGOIO_API ? "usa-1" : "env" });
 
   const exportTag = await enterExportTag("export_id");
   const entities = await chooseEntities([], ["dictionaries", "run"]);

--- a/src/commands/profile/export/export.ts
+++ b/src/commands/profile/export/export.ts
@@ -90,8 +90,8 @@ async function enterExportTag(defaultTag: string) {
 }
 
 async function confirmEnvironments(userConfig: IExport) {
-  const exportAcc = new Account({ token: userConfig.export.token, region: "usa-1" });
-  const importAcc = new Account({ token: userConfig.import.token, region: "usa-1" });
+  const exportAcc = new Account({ token: userConfig.export.token, region: !process.env.TAGOIO_API ? "usa-1" : "env" });
+  const importAcc = new Account({ token: userConfig.import.token, region: !process.env.TAGOIO_API ? "usa-1" : "env" });
 
   const errorWhenReading = (error: any, type: string) => {
     errorHandler(`${type} profile: ${error}`);
@@ -163,8 +163,8 @@ async function startExport(options: IExportOptions) {
     return;
   }
 
-  const account = new Account({ token: userConfig.export.token, region: "usa-1" });
-  const import_account = new Account({ token: userConfig.import.token, region: "usa-1" });
+  const account = new Account({ token: userConfig.export.token, region: !process.env.TAGOIO_API ? "usa-1" : "env" });
+  const import_account = new Account({ token: userConfig.import.token, region: !process.env.TAGOIO_API ? "usa-1" : "env" });
 
   const import_rule = ENTITY_ORDER.filter((entity) => userConfig.entities.includes(entity));
   let export_holder: IExportHolder = {

--- a/src/commands/profile/export/services/analysis-export.ts
+++ b/src/commands/profile/export/services/analysis-export.ts
@@ -1,9 +1,9 @@
+import zlib from "zlib";
 import axios from "axios";
 import prompts from "prompts";
-import zlib from "zlib";
 
 import { Account } from "@tago-io/sdk";
-import { AnalysisInfo } from "@tago-io/sdk/out/modules/Account/analysis.types";
+import { AnalysisInfo } from "@tago-io/sdk/lib/types";
 
 import { infoMSG } from "../../../../lib/messages";
 import { replaceObj } from "../../../../lib/replace-obj";

--- a/src/commands/profile/export/services/devices-export.ts
+++ b/src/commands/profile/export/services/devices-export.ts
@@ -34,7 +34,7 @@ async function deviceExport(account: Account, import_account: Account, export_ho
       ({ device_id: target_id, token: new_token } = await import_account.devices.create(new_device));
 
       if (config.data && config.data.length > 0) {
-        const device = new Device({ token: new_token, region: "usa-1" });
+        const device = new Device({ token: new_token, region: !process.env.TAGOIO_API ? "usa-1" : "env" });
         const old_device = new Device({ token });
 
         const data = await old_device.getData({

--- a/src/commands/start-config.ts
+++ b/src/commands/start-config.ts
@@ -34,10 +34,10 @@ async function createEnvironmentToken(environment: string) {
   }
   infoMSG(`You can create a token by running: ${highlightMSG("tagoio login")}`);
 
-  const options = { token: undefined, tagoDeployUrl: undefined };
+  const options = { token: undefined, tagoDeployUrl: undefined, tagoDeploySse: undefined };
   await tagoLogin(environment, options);
 
-  return { profileToken: options.token, tagoDeployUrl: options?.tagoDeployUrl };
+  return { profileToken: options.token, tagoDeployUrl: options?.tagoDeployUrl, tagoDeploySse: options?.tagoDeploySse };
 }
 
 /**
@@ -155,6 +155,7 @@ async function startConfig(environment: string, { token }: ConfigOptions) {
       const data = await createEnvironmentToken(environment);
       token = data?.profileToken;
       configFile.tagoDeployUrl = data?.tagoDeployUrl || "";
+      configFile.tagoDeploySse = data?.tagoDeploySse || "";
     }
   } else {
     writeToken(token, environment);
@@ -167,10 +168,6 @@ async function startConfig(environment: string, { token }: ConfigOptions) {
 
   if (!configFile.buildPath) {
     configFile.buildPath = await promptTextToEnter(`Enter the path of your ${kleur.cyan("building")} folder (typescript): `, "./build");
-  }
-
-  if (!configFile.tagoDeploySse) {
-    configFile.tagoDeploySse = "";
   }
 
   // Return if token is not found

--- a/src/commands/start-config.ts
+++ b/src/commands/start-config.ts
@@ -171,6 +171,10 @@ async function startConfig(environment: string, { token }: ConfigOptions) {
     configFile.tagoDeployUrl = "";
   }
 
+  if (!configFile.tagoDeploySse) {
+    configFile.tagoDeploySse = "";
+  }
+
   // Return if token is not found
   if (!token) {
     return;

--- a/src/commands/start-config.ts
+++ b/src/commands/start-config.ts
@@ -167,6 +167,10 @@ async function startConfig(environment: string, { token }: ConfigOptions) {
     configFile.buildPath = await promptTextToEnter(`Enter the path of your ${kleur.cyan("building")} folder (typescript): `, "./build");
   }
 
+  if (!configFile.tagoDeployUrl) {
+    configFile.tagoDeployUrl = "";
+  }
+
   // Return if token is not found
   if (!token) {
     return;

--- a/src/commands/start-config.ts
+++ b/src/commands/start-config.ts
@@ -34,10 +34,10 @@ async function createEnvironmentToken(environment: string) {
   }
   infoMSG(`You can create a token by running: ${highlightMSG("tagoio login")}`);
 
-  const options = { token: undefined };
+  const options = { token: undefined, tagoDeployUrl: undefined };
   await tagoLogin(environment, options);
 
-  return options.token;
+  return { profileToken: options.token, tagoDeployUrl: options?.tagoDeployUrl };
 }
 
 /**
@@ -152,7 +152,9 @@ async function startConfig(environment: string, { token }: ConfigOptions) {
   if (!token) {
     token = readToken(environment);
     if (!token) {
-      token = await createEnvironmentToken(environment);
+      const data = await createEnvironmentToken(environment);
+      token = data?.profileToken;
+      configFile.tagoDeployUrl = data?.tagoDeployUrl || "";
     }
   } else {
     writeToken(token, environment);
@@ -165,10 +167,6 @@ async function startConfig(environment: string, { token }: ConfigOptions) {
 
   if (!configFile.buildPath) {
     configFile.buildPath = await promptTextToEnter(`Enter the path of your ${kleur.cyan("building")} folder (typescript): `, "./build");
-  }
-
-  if (!configFile.tagoDeployUrl) {
-    configFile.tagoDeployUrl = "";
   }
 
   if (!configFile.tagoDeploySse) {

--- a/src/index.ts
+++ b/src/index.ts
@@ -34,9 +34,15 @@ const defaultEnvironment = process.env.TAGOIO_DEFAULT || "";
  */
 async function getAllCommands(program: Command) {
   const configFile = getConfigFile();
+
   if (configFile?.tagoDeployUrl) {
-    process.env.TAGOIO_API = configFile?.tagoDeployUrl;
+    process.env.TAGOIO_API = configFile.tagoDeployUrl;
   }
+
+  if (configFile?.tagoDeploySse) {
+    process.env.TAGOIO_SSE = configFile.tagoDeploySse;
+  }
+
   analysisCommands(program);
   deviceCommands(program);
   dashboardCommands(program);

--- a/src/index.ts
+++ b/src/index.ts
@@ -33,6 +33,10 @@ const defaultEnvironment = process.env.TAGOIO_DEFAULT || "";
  * @returns A Promise that resolves when all commands have been added.
  */
 async function getAllCommands(program: Command) {
+  const configFile = getConfigFile();
+  if (configFile?.tagoDeployUrl) {
+    process.env.TAGOIO_API = configFile?.tagoDeployUrl;
+  }
   analysisCommands(program);
   deviceCommands(program);
   dashboardCommands(program);

--- a/src/lib/config-file.ts
+++ b/src/lib/config-file.ts
@@ -20,6 +20,7 @@ interface IConfigFileEnvs {
 interface IConfigFile {
   profileToken?: string;
   tagoDeployUrl?: string;
+  tagoDeploySse?: string;
   analysisPath: string;
   buildPath: string;
   default: string;

--- a/src/lib/config-file.ts
+++ b/src/lib/config-file.ts
@@ -19,6 +19,7 @@ interface IConfigFileEnvs {
 }
 interface IConfigFile {
   profileToken?: string;
+  tagoDeployUrl?: string;
   analysisPath: string;
   buildPath: string;
   default: string;


### PR DESCRIPTION
This pull request introduces the ability for users to configure the URLs for both the API and SSE endpoints of the TagoDeploy service.

- To set the URL for the API in the TagoDeploy service, update the `tagoDeployUrl` field in the `tagoconfig.json` file with the URL of your server.
- To set the URL for SSE in the TagoDeploy service, update the `tagoDeploySse` field in the `tagoconfig.json` file with the URL of your server.