### PR TITLE
Update region to extended TagoIO Deploy support

### DIFF
--- a/docs/schema.json
+++ b/docs/schema.json
@@ -40,6 +40,16 @@
               "description": "Email of the account",
               "type": "string",
               "format": "email"
+          },
+          "tagoAPIURL": {
+              "description": "URL to API for TagoDeploy server",
+              "type": "string",
+              "format": "uri-reference"
+          },
+          "tagoSSEURL": {
+            "description": "URL to SSE for TagoDeploy server",
+            "type": "string",
+            "format": "uri-reference"
           }
       }
     }
@@ -49,16 +59,6 @@
         "description": "Path from the root of the project to the analysis folder",
           "type": "string",
           "format": "uri-reference"
-      },
-      "tagoDeployUrl": {
-          "description": "URL to API for TagoDeploy server",
-          "type": "string",
-          "format": "uri-reference"
-      },
-      "tagoDeploySse": {
-        "description": "URL to SSE for TagoDeploy server",
-        "type": "string",
-        "format": "uri-reference"
       },
       "buildPath": {
           "description": "Path from the root of the project to the build folder",

--- a/src/commands/analysis/analysis-console.ts
+++ b/src/commands/analysis/analysis-console.ts
@@ -92,7 +92,7 @@ async function connectAnalysisConsole(scriptName: string | void, options: { envi
     return;
   }
 
-  const account = new Account({ token: config.profileToken, region: !process.env.TAGOIO_API ? "usa-1" : "env" });
+  const account = new Account({ token: config.profileToken, region: config.profileRegion });
   const analysis_info = await account.analysis.info(scriptObj.id);
   if (!analysis_info) {
     errorHandler(`Analysis with ID: ${scriptObj.id} couldn't be found.`);

--- a/src/commands/analysis/analysis-set-mode.ts
+++ b/src/commands/analysis/analysis-set-mode.ts
@@ -67,7 +67,7 @@ async function analysisSetMode(userInputName: string | void, options: { environm
     return;
   }
 
-  const account = new Account({ token: config.profileToken, region: !process.env.TAGOIO_API ? "usa-1" : "env" });
+  const account = new Account({ token: config.profileToken, region: config.profileRegion });
   const analysisFilterName = userInputName ? `*${userInputName}*` : undefined;
 
   // Get analysis list from TagoIO

--- a/src/commands/analysis/deploy.ts
+++ b/src/commands/analysis/deploy.ts
@@ -125,7 +125,7 @@ async function deployAnalysis(cmdScriptName: string, options: { environment: str
     return;
   }
 
-  const account = new Account({ token: config.profileToken, region: !process.env.TAGOIO_API ? "usa-1" : "env" });
+  const account = new Account({ token: config.profileToken, region: config.profileRegion });
   for (const { id, fileName } of scriptList) {
     await buildScript(account, fileName, id, config);
   }

--- a/src/commands/analysis/run-analysis.ts
+++ b/src/commands/analysis/run-analysis.ts
@@ -74,7 +74,7 @@ async function runAnalysis(scriptName: string | undefined, options: { environmen
     return process.exit();
   }
 
-  const account = new Account({ token: config.profileToken, region: !process.env.TAGOIO_API ? "usa-1" : "env" });
+  const account = new Account({ token: config.profileToken, region: config.profileRegion });
 
   let { token: analysisToken, run_on, name } = await account.analysis.info(scriptToRun.id);
   successMSG(`> Analysis found: ${highlightMSG(scriptToRun.fileName)} (${name}}) [${highlightMSG(analysisToken)}].`);

--- a/src/commands/analysis/trigger-analysis.ts
+++ b/src/commands/analysis/trigger-analysis.ts
@@ -24,7 +24,7 @@ async function triggerAnalysis(scriptName: string | void, options: { environment
     return;
   }
 
-  const account = new Account({ token: config.profileToken, region: !process.env.TAGOIO_API ? "usa-1" : "env" });
+  const account = new Account({ token: config.profileToken, region: config.profileRegion });
   const analysisList = config.analysisList.filter((x) => x.fileName);
 
   let script: IEnvironment["analysisList"][0] | undefined;

--- a/src/commands/dashboard/copy-tab.ts
+++ b/src/commands/dashboard/copy-tab.ts
@@ -110,7 +110,7 @@ async function copyTabWidgets(dashID: string, options: IOptions) {
     return;
   }
 
-  const account = new Account({ token: config.profileToken, region: !process.env.TAGOIO_API ? "usa-1" : "env" });
+  const account = new Account({ token: config.profileToken, region: config.profileRegion });
   if (!dashID) {
     dashID = await pickDashboardIDFromTagoIO(account);
   }

--- a/src/commands/devices/change-network.ts
+++ b/src/commands/devices/change-network.ts
@@ -1,0 +1,85 @@
+import axios from "axios";
+import kleur from "kleur";
+
+import { Account } from "@tago-io/sdk";
+
+import { getEnvironmentConfig } from "../../lib/config-file";
+import { errorHandler, infoMSG, successMSG } from "../../lib/messages";
+import { pickDeviceIDFromTagoIO } from "../../prompt/pick-device-id-from-tagoio";
+import { promptTextToEnter } from "../../prompt/text-prompt";
+
+interface BucketSettings {
+  network: string;
+  connector: string;
+}
+
+type environmentConfigResponse = NonNullable<ReturnType<typeof getEnvironmentConfig>>;
+
+
+async function updateDevice(config: environmentConfigResponse, deviceID: string, settings: BucketSettings) {
+  const account = new Account({ token: config.profileToken, region: config.profileRegion });
+
+  const tokens = await account.devices.tokenList(deviceID);
+  const tokenList = tokens.map((token) => token.token);
+
+  if (tokenList) {
+    for (const token of tokenList) {
+      await account.devices.tokenDelete(token);
+    }
+  }
+
+  await account.devices.edit(deviceID, { network: settings.network, connector: settings.connector, active: true });
+
+  for (const token of tokens) {
+    const serieNumber =  token.serie_number as string | undefined;
+    await account.devices.tokenCreate(deviceID, { serie_number: serieNumber, name: token.name, permission: "full" });
+  }
+
+  successMSG(`> ${deviceID} - ${settings.network} network and ${settings.connector} connector updated successfully`);
+}
+
+async function changeNetworkOrConnector(id: string, options: { environment: string; networkID: string; connectorID: string }) {
+  const config = getEnvironmentConfig(options.environment);
+  if (!config || !config.profileToken) {
+    errorHandler("Environment not found");
+    return;
+  }
+
+  let { networkID, connectorID } = options;
+
+  const account = new Account({ token: config.profileToken, region: "usa-1" });
+  const deviceID = id || (await pickDeviceIDFromTagoIO(account));
+  if (!deviceID) {
+    return;
+  }
+
+  const deviceInfo = await account.devices.info(deviceID);
+  infoMSG(`> ${deviceInfo.name} - ${kleur.blue(deviceID)}\n`);
+
+  if (!networkID) {
+    networkID = await promptTextToEnter("Enter the network ID");
+  }
+
+  if (!connectorID) {
+    connectorID = await promptTextToEnter("Enter the connector ID");
+  }
+
+  if (!networkID && !connectorID) {
+    errorHandler("Network or Connector ID is required");
+    return;
+  }
+
+  if (networkID === deviceInfo.network && connectorID === deviceInfo.connector) {
+    errorHandler("Network and Connector are already set to this device");
+    return;
+  }
+
+  const updateInfo = {
+    network: networkID || deviceInfo.network,
+    connector: connectorID || deviceInfo.connector,
+  };
+
+  await updateDevice(config, deviceID, updateInfo);
+}
+
+export { changeNetworkOrConnector }

--- a/src/commands/devices/copy-data.ts
+++ b/src/commands/devices/copy-data.ts
@@ -38,7 +38,7 @@ async function copyDeviceData(options: IOptions) {
   }
 
   if (!options.from || !options.to) {
-    const account = new Account({ token: config.profileToken, region: !process.env.TAGOIO_API ? "usa-1" : "env" });
+    const account = new Account({ token: config.profileToken, region: config.profileRegion });
     options.from = await pickDeviceIDFromTagoIO(account, "Choose a device to copy the data from:");
     options.to = await pickDeviceIDFromTagoIO(account, "Choose a device to copy the data to: ");
   }
@@ -46,7 +46,7 @@ async function copyDeviceData(options: IOptions) {
   let deviceFrom: Device | undefined;
   let deviceTo: Device | undefined;
   if (options.from?.length === 24 || options.to?.length === 24) {
-    const account = new Account({ token: config.profileToken, region: !process.env.TAGOIO_API ? "usa-1" : "env" });
+    const account = new Account({ token: config.profileToken, region: config.profileRegion });
 
     if (options.from.length === 24) {
       deviceFrom = await Utils.getDevice(account, options.from);

--- a/src/commands/devices/data-get.ts
+++ b/src/commands/devices/data-get.ts
@@ -89,7 +89,7 @@ async function getDeviceData(idOrToken: string, options: IOptions) {
     errorHandler("Environment not found");
     return;
   }
-  const account = new Account({ token: config.profileToken, region: !process.env.TAGOIO_API ? "usa-1" : "env" });
+  const account = new Account({ token: config.profileToken, region: config.profileRegion });
   if (!idOrToken) {
     idOrToken = await pickDeviceIDFromTagoIO(account);
   }

--- a/src/commands/devices/data-post.ts
+++ b/src/commands/devices/data-post.ts
@@ -1,4 +1,5 @@
 import { Account, Device, Utils } from "@tago-io/sdk";
+
 import { getEnvironmentConfig } from "../../lib/config-file";
 import { errorHandler, successMSG } from "../../lib/messages";
 import { pickDeviceIDFromTagoIO } from "../../prompt/pick-device-id-from-tagoio";
@@ -15,7 +16,7 @@ async function postDeviceData(idOrToken: string, options: IOptions) {
     return;
   }
 
-  const account = new Account({ token: config.profileToken, region: !process.env.TAGOIO_API ? "usa-1" : "env" });
+  const account = new Account({ token: config.profileToken, region: config.profileRegion });
   if (!idOrToken) {
     idOrToken = await pickDeviceIDFromTagoIO(account);
   }

--- a/src/commands/devices/device-bkp.ts
+++ b/src/commands/devices/device-bkp.ts
@@ -1,5 +1,5 @@
-import { readFileSync, writeFileSync } from "fs";
 import axios from "axios";
+import { readFileSync, writeFileSync } from "fs";
 import kleur from "kleur";
 import { DateTime } from "luxon";
 
@@ -111,7 +111,7 @@ async function bkpDeviceData(idOrToken: string, options: IOptions) {
     return;
   }
 
-  const account = new Account({ token: config.profileToken, region: !process.env.TAGOIO_API ? "usa-1" : "env" });
+  const account = new Account({ token: config.profileToken, region: config.profileRegion });
   if (!idOrToken) {
     idOrToken = await pickDeviceIDFromTagoIO(account);
   }

--- a/src/commands/devices/device-info.ts
+++ b/src/commands/devices/device-info.ts
@@ -13,7 +13,7 @@ async function deviceInfo(idOrToken: string, options: { environment: string; raw
     return;
   }
 
-  const account = new Account({ token: config.profileToken, region: !process.env.TAGOIO_API ? "usa-1" : "env" });
+  const account = new Account({ token: config.profileToken, region: config.profileRegion });
   if (!idOrToken) {
     idOrToken = await pickDeviceIDFromTagoIO(account);
   }

--- a/src/commands/devices/device-list.ts
+++ b/src/commands/devices/device-list.ts
@@ -80,7 +80,7 @@ async function deviceList(options: IOptions) {
     return;
   }
 
-  const account = new Account({ token: config.profileToken });
+  const account = new Account({ token: config.profileToken, region: config.profileRegion });
   const filter: DeviceQuery = { amount: 50, fields: ["id", "name", "active", "last_input"], filter: { tags: [{}] } };
   if (filter.filter && options.name) {
     filter.filter.name = `*${options.name}*`;

--- a/src/commands/devices/device-live-inspector.ts
+++ b/src/commands/devices/device-live-inspector.ts
@@ -104,7 +104,7 @@ async function inspectorConnection(deviceIdOrToken: string, options: IOptions) {
     return;
   }
 
-  const account = new Account({ token: config.profileToken, region: !process.env.TAGOIO_API ? "usa-1" : "env" });
+  const account = new Account({ token: config.profileToken, region: config.profileRegion });
   if (!deviceIdOrToken) {
     deviceIdOrToken = await pickDeviceIDFromTagoIO(account);
   }

--- a/src/commands/list-env.ts
+++ b/src/commands/list-env.ts
@@ -1,6 +1,6 @@
 import { Account } from "@tago-io/sdk";
 
-import { getConfigFile, writeToConfigFile } from "../lib/config-file";
+import { getConfigFile, getProfileRegion, writeToConfigFile } from "../lib/config-file";
 import { infoMSG } from "../lib/messages";
 import { readToken } from "../lib/token";
 
@@ -22,8 +22,9 @@ async function fixEnvironments(configFile: ReturnType<typeof getConfigFile>, env
     if (!token) {
       continue;
     }
+    const region = getProfileRegion(environment);
 
-    const account = new Account({ token });
+    const account = new Account({ token, region });
     const profile = await account.profiles.info("current").catch((error) => {
       console.error(`Error getting profile info for ${env}: ${error.message}`);
       return;

--- a/src/commands/login.ts
+++ b/src/commands/login.ts
@@ -11,7 +11,7 @@ import { writeToken } from "../lib/token";
  */
 async function setTagoDeployUrl(): Promise<{ urlAPI: string; urlSSE: string } | undefined> {
   const { tagoDeployUrl } = await prompts({
-    message: "Do you want to pass on the tagoDeploy URL?",
+    message: "Do you have a TagoIO Deploy customized API Endpoint?",
     type: "confirm",
     name: "tagoDeployUrl",
   });
@@ -19,14 +19,15 @@ async function setTagoDeployUrl(): Promise<{ urlAPI: string; urlSSE: string } | 
     return;
   }
 
-  const { urlAPI } = await prompts({ type: "text", name: "urlAPI", message: "Set the URL for the API service: " });
+  const { urlAPI } = await prompts({ type: "text", name: "urlAPI", message: "Set the URL for the API service: ", hint: "https://api.tago.io" });
   if (!urlAPI) {
     return;
   }
 
-  const urlSSE = urlAPI.replace("https://api.", "https://sse.").replace(".tago-io.net", ".tago-io.net/events");
-  process.env.TAGOIO_API = urlAPI;
-  process.env.TAGOIO_SSE = urlSSE;
+  let { urlSSE } = await prompts({ type: "text", name: "urlSSE", message: "Set the URL for the SSE service: ", hint: "https://sse.tago.io" });
+  if (!urlSSE) {
+    urlSSE = urlAPI.replace("https://api.", "https://sse.").replace(".tago-io.net", ".tago-io.net/events");
+  }
 
   return { urlAPI, urlSSE };
 }

--- a/src/commands/profile/export/export-setup.ts
+++ b/src/commands/profile/export/export-setup.ts
@@ -124,7 +124,7 @@ async function setupExport(options: { setup: string }) {
     return;
   }
 
-  const account = new Account({ token: config.profileToken, region: !process.env.TAGOIO_API ? "usa-1" : "env" });
+  const account = new Account({ token: config.profileToken, region: config.profileRegion });
 
   const exportTag = await enterExportTag("export_id");
   const entities = await chooseEntities([], ["dictionaries", "run"]);

--- a/src/commands/profile/export/export.ts
+++ b/src/commands/profile/export/export.ts
@@ -4,9 +4,9 @@ import prompts from "prompts";
 import { Account } from "@tago-io/sdk";
 
 import { addOnGitIgnore } from "../../../lib/add-to-gitignore";
+import { getEnvironmentConfig } from "../../../lib/config-file";
 import { getCurrentFolder } from "../../../lib/get-current-folder";
 import { errorHandler, infoMSG, successMSG } from "../../../lib/messages";
-import { readToken } from "../../../lib/token";
 import { confirmPrompt } from "../../../prompt/confirm";
 import { pickEnvironment } from "../../../prompt/pick-environment";
 import { setupExport } from "./export-setup";
@@ -41,22 +41,26 @@ async function resolveTokens(userConfig: IExport, options: IExportOptions) {
   }
 
   if (options.from) {
-    const token = readToken(options.from);
-    if (!token) {
+    const config = getEnvironmentConfig(options.from);
+    if (!config || !config.profileToken) {
       errorHandler(`Token for environment ${options.from} not found. Did you try "tagoio login ${options.from}" ?`);
       process.exit(0);
     }
-    userConfig.export.token = token;
+
+    userConfig.export.token = config.profileToken;
+    userConfig.export.region = config.profileRegion;
     infoMSG(`Export from ${kleur.cyan(options.from)} environment selected.`);
   }
 
   if (options.to) {
-    const token = readToken(options.to);
-    if (!token) {
+    const config = getEnvironmentConfig(options.to);
+    if (!config || !config.profileToken) {
       errorHandler(`Token for environment ${options.to} not found. Did you try "tagoio login ${options.to}" ?`);
       process.exit(0);
     }
-    userConfig.import.token = token;
+    
+    userConfig.import.token = config.profileToken;
+    userConfig.import.region = config.profileRegion;
     infoMSG(`Export to ${kleur.cyan(options.to)} environment selected.`);
   }
 }
@@ -90,8 +94,8 @@ async function enterExportTag(defaultTag: string) {
 }
 
 async function confirmEnvironments(userConfig: IExport) {
-  const exportAcc = new Account({ token: userConfig.export.token, region: !process.env.TAGOIO_API ? "usa-1" : "env" });
-  const importAcc = new Account({ token: userConfig.import.token, region: !process.env.TAGOIO_API ? "usa-1" : "env" });
+  const exportAcc = new Account({ token: userConfig.export.token, region: userConfig.export.region });
+  const importAcc = new Account({ token: userConfig.import.token, region: userConfig.import.region });
 
   const errorWhenReading = (error: any, type: string) => {
     errorHandler(`${type} profile: ${error}`);
@@ -130,11 +134,13 @@ async function collectParameters(options: IExportOptions) {
     // Account that entities will be copied from.
     export: {
       token: options?.["fromToken"] as string, // Development
+      region: "usa-1" // TODO: Add region param to cli command
     },
 
     // Account where the entities will be pasted to.
     import: {
       token: options?.["toToken"] as string,
+      region: "usa-1"// TODO: Add region param to cli command
     },
   };
 

--- a/src/commands/profile/export/export.ts
+++ b/src/commands/profile/export/export.ts
@@ -58,7 +58,7 @@ async function resolveTokens(userConfig: IExport, options: IExportOptions) {
       errorHandler(`Token for environment ${options.to} not found. Did you try "tagoio login ${options.to}" ?`);
       process.exit(0);
     }
-    
+
     userConfig.import.token = config.profileToken;
     userConfig.import.region = config.profileRegion;
     infoMSG(`Export to ${kleur.cyan(options.to)} environment selected.`);
@@ -134,13 +134,13 @@ async function collectParameters(options: IExportOptions) {
     // Account that entities will be copied from.
     export: {
       token: options?.["fromToken"] as string, // Development
-      region: "usa-1" // TODO: Add region param to cli command
+      region: "usa-1",
     },
 
     // Account where the entities will be pasted to.
     import: {
       token: options?.["toToken"] as string,
-      region: "usa-1"// TODO: Add region param to cli command
+      region: "usa-1",
     },
   };
 
@@ -169,8 +169,8 @@ async function startExport(options: IExportOptions) {
     return;
   }
 
-  const account = new Account({ token: userConfig.export.token, region: !process.env.TAGOIO_API ? "usa-1" : "env" });
-  const import_account = new Account({ token: userConfig.import.token, region: !process.env.TAGOIO_API ? "usa-1" : "env" });
+  const account = new Account({ token: userConfig.export.token, region: userConfig.export.region });
+  const import_account = new Account({ token: userConfig.import.token, region: userConfig.import.region });
 
   const import_rule = ENTITY_ORDER.filter((entity) => userConfig.entities.includes(entity));
   let export_holder: IExportHolder = {

--- a/src/commands/profile/export/types.ts
+++ b/src/commands/profile/export/types.ts
@@ -3,6 +3,8 @@
 // * This file is global types, it's used to remove "implicitly has an 'any' type" errors.
 // ? ====================================================================================
 
+import { GenericModuleParams } from "@tago-io/sdk/lib/common/TagoIOModule";
+
 interface IExportHolder {
   dashboards: { [key: string]: string };
   devices: { [key: string]: string };
@@ -19,9 +21,11 @@ interface IExport {
   data?: string[];
   export: {
     token: string;
+    region: GenericModuleParams["region"];
   };
   import: {
     token: string;
+    region: GenericModuleParams["region"];
   };
 }
 const ENTITY_ORDER: EntityType[] = ["devices", "analysis", "dashboards", "access", "run", "actions", "dictionaries"];

--- a/src/commands/start-config.ts
+++ b/src/commands/start-config.ts
@@ -4,6 +4,7 @@ import prompts, { Choice } from "prompts";
 import stringComparison from "string-comparison";
 
 import { Account } from "@tago-io/sdk";
+import { GenericModuleParams } from "@tago-io/sdk/lib/common/TagoIOModule";
 import { AnalysisInfo, AnalysisListItem } from "@tago-io/sdk/lib/types";
 
 import { getConfigFile, IEnvironment, writeConfigFileEnv, writeToConfigFile } from "../lib/config-file";
@@ -24,7 +25,7 @@ interface ConfigOptions {
  */
 async function createEnvironmentToken(environment: string) {
   const { tryLogin } = await prompts({
-    message: "Do you want to login and create a token now?",
+    message: "Do you want to login and create a profile-token now?",
     type: "confirm",
     name: "tryLogin",
     hint: "Press N to enter a token later",
@@ -34,10 +35,18 @@ async function createEnvironmentToken(environment: string) {
   }
   infoMSG(`You can create a token by running: ${highlightMSG("tagoio login")}`);
 
-  const options = { token: undefined, tagoDeployUrl: undefined, tagoDeploySse: undefined };
+  const options = {
+    token: undefined,
+    tagoDeployUrl: undefined,
+    tagoDeploySse: undefined,
+  };
   await tagoLogin(environment, options);
 
-  return { profileToken: options.token, tagoDeployUrl: options?.tagoDeployUrl, tagoDeploySse: options?.tagoDeploySse };
+  return {
+    profileToken: options.token,
+    tagoDeployUrl: options?.tagoDeployUrl,
+    tagoDeploySse: options?.tagoDeploySse,
+  };
 }
 
 /**
@@ -62,19 +71,30 @@ async function chooseAnalysis(analysisOptions: any[]) {
  * @param oldList - An optional array of previously selected analyses.
  * @returns An array of selected analyses with their IDs, names, and file names.
  */
-async function getAnalysisList(account: Account, oldList: IEnvironment["analysisList"] = []) {
-  const analysisList = await account.analysis.list({ amount: 35, fields: ["id", "name", "tags"] }).catch(errorHandler);
+async function getAnalysisList(
+  account: Account,
+  oldList: IEnvironment["analysisList"] = [],
+) {
+  const analysisList = await account.analysis
+    .list({ amount: 35, fields: ["id", "name", "tags"] })
+    .catch(errorHandler);
 
   if (!analysisList) {
     return [];
   }
 
-  const getName = (analysis: AnalysisListItem) => `[${analysis.id}] ${analysis.name}`;
+  const getName = (analysis: AnalysisListItem) =>
+    `[${analysis.id}] ${analysis.name}`;
 
   const oldIDList = new Set(oldList.map((x) => x.id));
-  const configList: AnalysisListItem<"id" | "name" | "tags">[] = analysisList.filter((x) => oldIDList.has(x.id));
+  const configList: AnalysisListItem<"id" | "name" | "tags">[] =
+    analysisList.filter((x) => oldIDList.has(x.id));
 
-  const analysisOptions = analysisList.map((x) => ({ title: getName(x), selected: configList.some((y) => y.id === x.id), value: x }));
+  const analysisOptions = analysisList.map((x) => ({
+    title: getName(x),
+    selected: configList.some((y) => y.id === x.id),
+    value: x,
+  }));
   const response = await chooseAnalysis(analysisOptions);
 
   const formatFileName = (x: string) => x.toLowerCase().replace(" ", "-");
@@ -94,7 +114,10 @@ async function getAnalysisList(account: Account, oldList: IEnvironment["analysis
  * @param analysisPath - The path to search for analysis scripts.
  * @returns A Promise that resolves to the updated analysis list with the selected script file names.
  */
-async function getAnalysisScripts(analysisList: IEnvironment["analysisList"], analysisPath: string) {
+async function getAnalysisScripts(
+  analysisList: IEnvironment["analysisList"],
+  analysisPath: string,
+) {
   infoMSG(`Searching for files at ${analysisPath}`);
   let files: Choice[] = readdirSync(analysisPath)
     .filter((x) => x.endsWith(".ts") || x.endsWith(".js") || x.endsWith(".py"))
@@ -102,7 +125,10 @@ async function getAnalysisScripts(analysisList: IEnvironment["analysisList"], an
 
   for (const analysis of analysisList) {
     files = files.sort((a, b) =>
-      stringComparison.cosine.distance(analysis.name, a.title) > stringComparison.cosine.distance(analysis.name, b.title) ? 1 : -1
+      stringComparison.cosine.distance(analysis.name, a.title) >
+      stringComparison.cosine.distance(analysis.name, b.title)
+        ? 1
+        : -1,
     );
 
     const editFile = files.find((x) => x.title === analysis.fileName);
@@ -139,7 +165,11 @@ async function getAnalysisScripts(analysisList: IEnvironment["analysisList"], an
 async function startConfig(environment: string, { token }: ConfigOptions) {
   // Prompt user to enter environment name if not provided
   if (!environment) {
-    ({ environment } = await prompts({ message: "Enter a name for this environment: ", type: "text", name: "environment" }));
+    ({ environment } = await prompts({
+      message: "Enter a name for this environment (e.g dev): ",
+      type: "text",
+      name: "environment",
+    }));
   }
 
   // Get config file or return if not found
@@ -148,14 +178,15 @@ async function startConfig(environment: string, { token }: ConfigOptions) {
     return;
   }
 
+  let tagoAPIURL, tagoSSEurl;
   // Get token from file or prompt user to create one
   if (!token) {
     token = readToken(environment);
     if (!token) {
       const data = await createEnvironmentToken(environment);
       token = data?.profileToken;
-      configFile.tagoDeployUrl = data?.tagoDeployUrl || "";
-      configFile.tagoDeploySse = data?.tagoDeploySse || "";
+      tagoAPIURL = data?.tagoDeployUrl;
+      tagoSSEurl = data?.tagoDeploySse;
     }
   } else {
     writeToken(token, environment);
@@ -163,11 +194,17 @@ async function startConfig(environment: string, { token }: ConfigOptions) {
 
   // Prompt user to enter analysis and build paths if not found in config file
   if (!configFile.analysisPath) {
-    configFile.analysisPath = await promptTextToEnter(`Enter the path of your ${kleur.cyan("analysis")} folder: `, "./src/analysis");
+    configFile.analysisPath = await promptTextToEnter(
+      `Enter the path of your ${kleur.cyan("analysis")} folder: `,
+      "./src/analysis",
+    );
   }
 
   if (!configFile.buildPath) {
-    configFile.buildPath = await promptTextToEnter(`Enter the path of your ${kleur.cyan("building")} folder (typescript): `, "./build");
+    configFile.buildPath = await promptTextToEnter(
+      `Enter the path of your ${kleur.cyan("building")} folder (typescript): `,
+      "./build",
+    );
   }
 
   // Return if token is not found
@@ -175,15 +212,37 @@ async function startConfig(environment: string, { token }: ConfigOptions) {
     return;
   }
 
+  let region: GenericModuleParams["region"] = "usa-1";
+  if (tagoAPIURL) {
+    region = {
+      api: tagoAPIURL || "",
+      sse: tagoSSEurl || "",
+      realtime: "", // Not used in the CLI
+    }
+  }
+
   // Get account info and analysis list
-  const account = new Account({ token });
+  const account = new Account({ token: token, region });
   const profile = await account.profiles.info("current");
   const accountInfo = await account.info();
-  let analysisList = await getAnalysisList(account, configFile[environment]?.analysisList);
-  analysisList = await getAnalysisScripts(analysisList, configFile.analysisPath);
+  let analysisList = await getAnalysisList(
+    account,
+    configFile[environment]?.analysisList,
+  );
+  analysisList = await getAnalysisScripts(
+    analysisList,
+    configFile.analysisPath,
+  );
 
   // Create new environment object and write to config file
-  const newEnv: IEnvironment = { analysisList: analysisList, id: profile.info.id, profileName: profile.info.name, email: accountInfo.email };
+  const newEnv: IEnvironment = {
+    analysisList: analysisList,
+    id: profile.info.id,
+    profileName: profile.info.name,
+    email: accountInfo.email,
+    tagoSSEURL: tagoSSEurl,
+    tagoAPIURL: tagoAPIURL,
+  };
   writeToConfigFile(configFile);
   writeConfigFileEnv(environment, newEnv);
 }

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,7 +1,7 @@
 #!/usr/bin/env node
-import { readFileSync } from "fs";
 import { Command } from "commander";
 import dotenv from "dotenv";
+import { readFileSync } from "fs";
 import kleur from "kleur";
 
 import { analysisCommands } from "./commands/analysis";
@@ -33,16 +33,6 @@ const defaultEnvironment = process.env.TAGOIO_DEFAULT || "";
  * @returns A Promise that resolves when all commands have been added.
  */
 async function getAllCommands(program: Command) {
-  const configFile = getConfigFile();
-
-  if (configFile?.tagoDeployUrl) {
-    process.env.TAGOIO_API = configFile.tagoDeployUrl;
-  }
-
-  if (configFile?.tagoDeploySse) {
-    process.env.TAGOIO_SSE = configFile.tagoDeploySse;
-  }
-
   analysisCommands(program);
   deviceCommands(program);
   dashboardCommands(program);


### PR DESCRIPTION
Extend support to TagoDeploy on every function by replacing hardcoded region values with profileRegion for improved consistency.

# Requirements
- Update of SDK to include tago-io/sdk-js#128