### PR TITLE
Rewrite tagoio init to follow clig.dev

### DIFF
--- a/src/commands/start-config.test.ts
+++ b/src/commands/start-config.test.ts
@@ -3,9 +3,13 @@ import { tmpdir } from "node:os";
 import { join } from "node:path";
 import { afterEach, beforeEach, describe, expect, test, vi } from "vitest";
 
-// start-config.ts exports only `startConfig`, but it re-requires scanAnalysisFiles via startConfig's
-// path. The helper itself isn't exported, so we test it indirectly through the module under test.
-// For direct coverage we import the module after setting up a real temp directory to walk.
+const errorHandlerMock = vi.fn<(str: unknown) => never>(() => {
+  throw new Error("errorHandler called");
+});
+const detectInitStateMock = vi.fn();
+const exitMock = vi.fn(() => {
+  throw new Error("process.exit called");
+});
 
 vi.mock("../lib/config-file.js", () => ({
   getConfigFile: vi.fn(),
@@ -19,7 +23,7 @@ vi.mock("../lib/token.js", () => ({
 }));
 
 vi.mock("../lib/messages.js", () => ({
-  errorHandler: vi.fn(),
+  errorHandler: errorHandlerMock,
   highlightMSG: (s: string) => s,
   infoMSG: vi.fn(),
 }));
@@ -36,6 +40,19 @@ vi.mock("../lib/resolve-scope.js", () => ({
   globalConfigDir: () => "/home/user/.config/tagoio",
 }));
 
+vi.mock("../lib/init-state.js", () => ({
+  detectInitState: (envName: string) => detectInitStateMock(envName),
+}));
+
+vi.mock("../lib/init-summary.js", () => ({
+  banner: (scope: { root: string }) => `Initializing tagoio in ${scope.root}...`,
+  overwriteConfirmCopy: () => "OVERWRITE_COPY_STUB",
+  startStep: vi.fn(),
+  endStep: vi.fn(),
+  failStep: vi.fn(),
+  summaryBlock: () => "SUMMARY_BLOCK_STUB",
+}));
+
 vi.mock("../lib/scope-notice.js", () => ({
   printScopeBanner: vi.fn(),
 }));
@@ -49,38 +66,121 @@ vi.mock("../prompt/text-prompt.js", () => ({
   promptTextToEnter: vi.fn(),
 }));
 
-describe("startConfig (entry points)", () => {
+const localScope = {
+  scope: "local" as const,
+  root: "/repo",
+  configPath: "/repo/tagoconfig.json",
+  envFilePath: "/repo/.tagoio/personal.env",
+  configExists: true,
+};
+
+const freshState = {
+  scope: localScope,
+  isTTY: true,
+  configExists: true,
+  envExists: false,
+  tokenExists: false,
+};
+
+const reInitState = {
+  scope: localScope,
+  isTTY: true,
+  configExists: true,
+  envExists: true,
+  tokenExists: true,
+};
+
+describe("startConfig — clig.dev flow", () => {
   beforeEach(() => {
     vi.clearAllMocks();
+    detectInitStateMock.mockReset();
+    errorHandlerMock.mockClear();
+    exitMock.mockClear();
+    vi.spyOn(process.stderr, "write").mockImplementation(() => true);
+    vi.spyOn(process, "exit").mockImplementation(((code?: number) => {
+      throw new Error(`__exit:${code ?? 0}`);
+    }) as never);
   });
 
-  test("returns early when the config file is missing", async () => {
+  afterEach(() => {
+    vi.restoreAllMocks();
+  });
+
+  test("re-init confirm-no exits with 'Cancelled. No changes made.'", async () => {
+    detectInitStateMock.mockReturnValue(reInitState);
+    const { getConfigFile } = await import("../lib/config-file.js");
+    (getConfigFile as ReturnType<typeof vi.fn>).mockReturnValue({ dev: { id: "x" } });
+
+    const promptsModule = await import("prompts");
+    // First inject is the "Overwrite?" prompt → user says no.
+    promptsModule.default.inject([false]);
+
+    const { startConfig } = await import("./start-config.js");
+    await expect(startConfig("dev", { token: undefined })).rejects.toThrow(/__exit:0/);
+  });
+
+  test("re-init with --force skips the overwrite confirm prompt", async () => {
+    detectInitStateMock.mockReturnValue(reInitState);
     const { getConfigFile } = await import("../lib/config-file.js");
     (getConfigFile as ReturnType<typeof vi.fn>).mockReturnValue(undefined);
 
     const { startConfig } = await import("./start-config.js");
-    await expect(startConfig("prod", { token: undefined, environment: undefined })).resolves.toBeUndefined();
+    // No prompt injection — if a prompt fires, it would hang. With --force we expect
+    // it to skip the confirm and proceed (then exit early because getConfigFile returns undefined).
+    await expect(startConfig("dev", { token: "tok-1", force: true })).resolves.toBeUndefined();
   });
 
-  test("returns early when no token can be obtained", async () => {
-    const { getConfigFile } = await import("../lib/config-file.js");
-    const { readToken } = await import("../lib/token.js");
-    const { promptTextToEnter } = await import("../prompt/text-prompt.js");
-
-    (getConfigFile as ReturnType<typeof vi.fn>).mockReturnValue({ analysisPath: "./src/analysis", buildPath: "./build" });
-    (readToken as ReturnType<typeof vi.fn>).mockReturnValue(undefined);
-    (promptTextToEnter as ReturnType<typeof vi.fn>).mockResolvedValue("./src/analysis");
-
-    // We don't need to prompt the user for environment since we provide one.
-    // createEnvironmentToken -> user says no, returns undefined.
-    const promptsModule = await import("prompts");
-    promptsModule.default.inject([false]);
+  test("--no-input + existing env without --force errors with the --force hint", async () => {
+    detectInitStateMock.mockReturnValue(reInitState);
 
     const { startConfig } = await import("./start-config.js");
-    await expect(startConfig("prod", { token: undefined, environment: undefined })).resolves.toBeUndefined();
+    await expect(startConfig("dev", { token: "tok-1", input: false })).rejects.toThrow();
+    const errArg = errorHandlerMock.mock.calls[0][0] as string;
+    expect(errArg).toContain("--force");
+    expect(errArg).toContain("already exists");
+  });
+
+  test("--no-input without --token errors before any work", async () => {
+    detectInitStateMock.mockReturnValue(freshState);
+    const { getConfigFile } = await import("../lib/config-file.js");
+    (getConfigFile as ReturnType<typeof vi.fn>).mockReturnValue({});
+
+    const { startConfig } = await import("./start-config.js");
+    await expect(startConfig("dev", { input: false })).rejects.toThrow();
+    const errArg = errorHandlerMock.mock.calls[0][0] as string;
+    expect(errArg).toContain("--no-input requires --token");
+  });
+
+  test("--name flag overrides positional argument and emits a stderr note", async () => {
+    detectInitStateMock.mockReturnValue(reInitState);
+    const { startConfig } = await import("./start-config.js");
+    // Re-init w/ --no-input should error after the env-name resolution; that's enough
+    // to exercise the override path.
+    await expect(startConfig("positional", { name: "fromflag", input: false })).rejects.toThrow();
+
+    // Detect was called with the flag value, not the positional.
+    expect(detectInitStateMock).toHaveBeenCalledWith("fromflag");
+  });
+
+  test("uses default env 'dev' when neither positional nor --name is set", async () => {
+    detectInitStateMock.mockReturnValue(reInitState);
+    const { startConfig } = await import("./start-config.js");
+    await expect(startConfig("", { input: false })).rejects.toThrow();
+
+    expect(detectInitStateMock).toHaveBeenCalledWith("dev");
+  });
+
+  test("invalid --scope value errors actionably", async () => {
+    const { startConfig } = await import("./start-config.js");
+    await expect(startConfig("dev", { scope: "bogus" as never })).rejects.toThrow();
+    const errArg = errorHandlerMock.mock.calls[0][0] as string;
+    expect(errArg).toContain("Invalid --scope");
+    expect(errArg).toContain("'bogus'");
   });
 });
 
+// scanAnalysisFiles is exercised indirectly; the recursive walk itself is simple
+// fs traversal, covered by the real-fs test below.
 describe("scanAnalysisFiles (indirect)", () => {
   let tmpRoot: string;
 
@@ -99,9 +199,6 @@ describe("scanAnalysisFiles (indirect)", () => {
     mkdirSync(nested);
     writeFileSync(join(nested, "deep.js"), "");
 
-    // Load the module to access scanAnalysisFiles indirectly: since it isn't exported,
-    // we rely on its behaviour being exercised by getAnalysisScripts. Here we assert the
-    // directory walk itself via the real fs functions we just set up.
     const { readdirSync, statSync } = await import("node:fs");
     const items = readdirSync(tmpRoot);
     const collected: string[] = [];

--- a/src/commands/start-config.test.ts
+++ b/src/commands/start-config.test.ts
@@ -49,7 +49,11 @@ vi.mock("../lib/init-summary.js", () => ({
   overwriteConfirmCopy: () => "OVERWRITE_COPY_STUB",
   startStep: vi.fn(),
   endStep: vi.fn(),
-  failStep: vi.fn(),
+  // Real failStep is typed `never` and calls process.exit(1); model that here
+  // so callers can't fall through after a failed step.
+  failStep: (label: string) => {
+    throw new Error(`__failStep:${label}`);
+  },
   summaryBlock: () => "SUMMARY_BLOCK_STUB",
 }));
 
@@ -126,8 +130,9 @@ describe("startConfig — clig.dev flow", () => {
 
     const { startConfig } = await import("./start-config.js");
     // No prompt injection — if a prompt fires, it would hang. With --force we expect
-    // it to skip the confirm and proceed (then exit early because getConfigFile returns undefined).
-    await expect(startConfig("dev", { token: "tok-1", force: true })).resolves.toBeUndefined();
+    // it to skip the confirm and proceed; getConfigFile returns undefined, so the
+    // "Creating project structure" stage fails via failStep (which aborts).
+    await expect(startConfig("dev", { token: "tok-1", force: true })).rejects.toThrow(/__failStep:Creating project structure/);
   });
 
   test("--no-input + existing env without --force errors with the --force hint", async () => {

--- a/src/commands/start-config.ts
+++ b/src/commands/start-config.ts
@@ -8,7 +8,7 @@ import { getConfigFile, IEnvironment, writeConfigFileEnv, writeToConfigFile } fr
 import { detectInitState, InitState } from "../lib/init-state.js";
 import { banner, endStep, failStep, overwriteConfirmCopy, startStep, summaryBlock } from "../lib/init-summary.js";
 import { errorHandler, highlightMSG, infoMSG } from "../lib/messages.js";
-import { globalConfigDir, setScopeOverride } from "../lib/resolve-scope.js";
+import { globalConfigDir, resolveScope, setScopeOverride } from "../lib/resolve-scope.js";
 import { readToken, writeToken } from "../lib/token.js";
 import { promptTextToEnter } from "../prompt/text-prompt.js";
 import { getTagoDeployURL, tagoLogin } from "./login.js";
@@ -30,7 +30,8 @@ interface ConfigOptions {
   sseEndpoint?: string;
   /**
    * Commander stores `--no-input` as `input: false` (negation flag), with the
-   * default being `true`. We normalize to a `noInput` boolean inside startConfig.
+   * default being `true`. startConfig normalizes this (plus the non-TTY case)
+   * into a single `noInput` boolean.
    */
   input?: boolean;
   /** Skip the existing-config overwrite confirmation. */
@@ -177,11 +178,11 @@ function resolveEnvName(positional: string | undefined, flag: string | undefined
  * overwrite, hard-errors under --no-input, or returns silently when nothing
  * needs confirming.
  */
-async function handleExistingEnv(state: InitState, envName: string, options: ConfigOptions): Promise<void> {
+async function handleExistingEnv(state: InitState, envName: string, options: ConfigOptions, noInput: boolean): Promise<void> {
   if (!state.envExists || options.force) {
     return;
   }
-  if ((options.input === false)) {
+  if (noInput) {
     errorHandler(
       `Configuration for env '${envName}' already exists at ${state.scope.configPath}. Pass --force to overwrite, or pick a different env name.`,
     );
@@ -204,7 +205,7 @@ async function handleExistingEnv(state: InitState, envName: string, options: Con
  * the existing-config decision tree from #4. Bootstraps the stub config file
  * at the chosen scope so the rest of init has something to read/write.
  */
-async function resolveTargetScope(options: ConfigOptions): Promise<void> {
+async function resolveTargetScope(options: ConfigOptions, noInput: boolean): Promise<void> {
   if (options.scope === "global") {
     bootstrapGlobalConfig();
     return;
@@ -214,12 +215,11 @@ async function resolveTargetScope(options: ConfigOptions): Promise<void> {
     return;
   }
   // No flag: rely on the resolver. If neither config exists, prompt (or
-  // default to local under --no-input).
-  const initial = detectInitState("__probe__");
-  if (initial.configExists) {
+  // default to local in non-interactive mode).
+  if (resolveScope().configExists) {
     return;
   }
-  if ((options.input === false)) {
+  if (noInput) {
     bootstrapLocalConfig();
     return;
   }
@@ -251,20 +251,29 @@ async function startConfig(positional: string, options: ConfigOptions = {}): Pro
 
   const envName = resolveEnvName(positional, options.name);
 
-  // Step 2 (early): bootstrap the chosen scope's tagoconfig.json. We need
-  // this before detectInitState() so envExists/tokenExists reflect the
-  // resolved scope and not the cwd-default fallback.
-  await resolveTargetScope(options);
+  // Step 2 (early): bootstrap the chosen scope's tagoconfig.json. Must run
+  // before detectInitState() so envExists/tokenExists (and state.scope under
+  // --scope global) reflect the resolved scope, not the cwd-default fallback.
+  // The TTY-vs-flag nuance does not matter here: this only decides WHERE to
+  // create a brand-new config when none exists yet.
+  await resolveTargetScope(options, options.input === false);
 
-  // Step 0: pre-flight detection.
+  // Step 0: pre-flight detection (reads on-disk state + isTTY).
   const state = detectInitState(envName);
+
+  // Non-interactive when --no-input is passed OR stdin is not a TTY (piped
+  // input, CI). Deriving from state.isTTY keeps the decision in one place and
+  // testable. Treating non-TTY as no-input prevents prompts() from returning
+  // undefined and silently proceeding on empty answers; instead we fail fast
+  // or require flags, exactly as --no-input does.
+  const noInput = options.input === false || !state.isTTY;
 
   // Step 1: banner + overwrite confirm.
   process.stderr.write(`${banner(state.scope)}\n`);
-  await handleExistingEnv(state, envName, options);
+  await handleExistingEnv(state, envName, options, noInput);
 
-  // Step 2 (continued): resolve token. --no-input requires -t.
-  if ((options.input === false) && !options.token && !state.tokenExists) {
+  // Step 2 (continued): resolve token. Non-interactive requires -t.
+  if (noInput && !options.token && !state.tokenExists) {
     errorHandler("--no-input requires --token <token> when no existing lock file is on disk for this env.");
   }
 
@@ -274,8 +283,9 @@ async function startConfig(positional: string, options: ConfigOptions = {}): Pro
   startStep("Creating project structure");
   const configFile = getConfigFile();
   if (!configFile) {
+    // failStep is typed `never` (it calls process.exit(1)), so init aborts here
+    // with a non-zero code instead of falling through and reporting success.
     failStep("Creating project structure", "could not read or create tagoconfig.json");
-    return;
   }
   endStep(`Created ${state.scope.configPath}`);
   filesWritten.push({ path: state.scope.configPath, description: "project configuration" });
@@ -296,7 +306,7 @@ async function startConfig(positional: string, options: ConfigOptions = {}): Pro
     token = readToken(envName);
   }
   if (!token) {
-    if ((options.input === false)) {
+    if (noInput) {
       errorHandler("--no-input requires --token <token> for authentication.");
     }
     const data = await createEnvironmentToken(envName);
@@ -305,7 +315,7 @@ async function startConfig(positional: string, options: ConfigOptions = {}): Pro
     tagoSSEURL = tagoSSEURL || data?.tagoDeploySse;
   } else if (options.token) {
     // Token came from the flag. Persist it to the lock file.
-    if (!(options.input === false) && !options.apiEndpoint) {
+    if (!noInput && !options.apiEndpoint) {
       const urlConfig = await getTagoDeployURL();
       tagoAPIURL = urlConfig?.urlAPI || tagoAPIURL;
       tagoSSEURL = urlConfig?.urlSSE || tagoSSEURL;
@@ -325,10 +335,10 @@ async function startConfig(positional: string, options: ConfigOptions = {}): Pro
 
   // Local-only prompts for analysis paths.
   if (state.scope.scope === "local") {
-    if (!configFile.analysisPath && !(options.input === false)) {
+    if (!configFile.analysisPath && !noInput) {
       configFile.analysisPath = await promptTextToEnter(`Enter the path of your ${kleur.cyan("analysis")} folder: `, "./src/analysis");
     }
-    if (!configFile.buildPath && !(options.input === false)) {
+    if (!configFile.buildPath && !noInput) {
       configFile.buildPath = await promptTextToEnter(`Enter the path of your ${kleur.cyan("building")} folder (typescript): `, "./build");
     }
   }
@@ -347,7 +357,6 @@ async function startConfig(positional: string, options: ConfigOptions = {}): Pro
     accountInfo = await account.info();
   } catch (err) {
     failStep("Authenticating with TagoIO", err);
-    process.exit(1);
   }
   endStep(`Authenticated as ${profile.info.name}`);
 
@@ -360,7 +369,7 @@ async function startConfig(positional: string, options: ConfigOptions = {}): Pro
     tagoAPIURL,
   };
   if (state.scope.scope === "local") {
-    if ((options.input === false)) {
+    if (noInput) {
       // Non-interactive: preserve whatever analysisList is already on disk
       // (re-init keeps it; fresh init starts empty). The user can populate it
       // by editing tagoconfig.json or rerunning init interactively.

--- a/src/commands/start-config.ts
+++ b/src/commands/start-config.ts
@@ -5,17 +5,36 @@ import kleur from "kleur";
 import prompts, { Choice } from "prompts";
 import stringComparison from "string-comparison";
 import { getConfigFile, IEnvironment, writeConfigFileEnv, writeToConfigFile } from "../lib/config-file.js";
+import { detectInitState, InitState } from "../lib/init-state.js";
+import { banner, endStep, failStep, overwriteConfirmCopy, startStep, summaryBlock } from "../lib/init-summary.js";
 import { errorHandler, highlightMSG, infoMSG } from "../lib/messages.js";
-import { globalConfigDir, resolveScope, setScopeOverride } from "../lib/resolve-scope.js";
-import { printScopeBanner } from "../lib/scope-notice.js";
+import { globalConfigDir, setScopeOverride } from "../lib/resolve-scope.js";
 import { readToken, writeToken } from "../lib/token.js";
 import { promptTextToEnter } from "../prompt/text-prompt.js";
 import { getTagoDeployURL, tagoLogin } from "./login.js";
 
+const DEFAULT_ENV = "dev";
+const DEFAULT_API_ENDPOINT = "https://api.tago.io";
+const DEFAULT_SSE_ENDPOINT = "https://sse.tago.io";
+
 interface ConfigOptions {
-  token: string | void;
-  environment: string | void;
+  /** Profile token; bypasses interactive login when set. */
+  token?: string;
+  /** Alias for the positional [environment] argument. Flag wins on conflict. */
+  name?: string;
+  /** Force local or global scope. Falls through to the decision tree if unset. */
   scope?: "local" | "global";
+  /** API endpoint URL. Must be paired with `sseEndpoint`. */
+  apiEndpoint?: string;
+  /** SSE endpoint URL. Must be paired with `apiEndpoint`. */
+  sseEndpoint?: string;
+  /**
+   * Commander stores `--no-input` as `input: false` (negation flag), with the
+   * default being `true`. We normalize to a `noInput` boolean inside startConfig.
+   */
+  input?: boolean;
+  /** Skip the existing-config overwrite confirmation. */
+  force?: boolean;
 }
 
 interface AnalysisFile {
@@ -25,12 +44,7 @@ interface AnalysisFile {
 
 const analysisPath = "./src/analysis";
 
-/**
- * Recursively scans a directory and its subdirectories for analysis files.
- * @param dirPath - The directory path to scan.
- * @param basePath - The base analysis path for relative path calculation.
- * @returns An array of file paths with their relative paths.
- */
+/** Recursively scans a directory for `.ts`/`.js` analysis files. */
 function scanAnalysisFiles(dirPath: string, basePath: string = dirPath): AnalysisFile[] {
   const files: AnalysisFile[] = [];
   const items = readdirSync(dirPath);
@@ -50,42 +64,6 @@ function scanAnalysisFiles(dirPath: string, basePath: string = dirPath): Analysi
   return files;
 }
 
-/**
- * Creates a TagoIO environment token.
- * @param environment - The name of the environment to create the token for.
- * @returns The created token, or undefined if the user chooses not to login.
- */
-async function createEnvironmentToken(environment: string) {
-  const { tryLogin } = await prompts({
-    message: "Do you want to login and create a profile-token now?",
-    type: "confirm",
-    name: "tryLogin",
-    hint: "Press N to enter a token later",
-  });
-  if (!tryLogin) {
-    return;
-  }
-  infoMSG(`You can create a token by running: ${highlightMSG("tagoio login")}`);
-
-  const options = {
-    token: undefined,
-    tagoDeployUrl: undefined,
-    tagoDeploySse: undefined,
-  };
-  await tagoLogin(environment, options);
-
-  return {
-    profileToken: options.token,
-    tagoDeployUrl: options?.tagoDeployUrl,
-    tagoDeploySse: options?.tagoDeploySse,
-  };
-}
-
-/**
- * Prompts the user to choose one or more analysis options from a list.
- * @param analysisOptions - An array of analysis options to choose from.
- * @returns An array of AnalysisInfo objects representing the user's selected options.
- */
 async function chooseAnalysis(analysisOptions: any[]) {
   const { response } = await prompts({
     type: "autocompleteMultiselect",
@@ -97,24 +75,15 @@ async function chooseAnalysis(analysisOptions: any[]) {
   return (response || []) as AnalysisInfo[];
 }
 
-/**
- * Retrieves a list of analyses from the TagoIO account and prompts the user to select which ones to use.
- * @param account - The TagoIO account object.
- * @param oldList - An optional array of previously selected analyses.
- * @returns An array of selected analyses with their IDs, names, and file names.
- */
 async function getAnalysisList(account: Account, oldList: NonNullable<IEnvironment["analysisList"]> = []) {
   const analysisList = await account.analysis.list({ amount: 35, fields: ["id", "name", "tags"] }).catch(errorHandler);
-
   if (!analysisList) {
     return [];
   }
 
   const getName = (analysis: AnalysisListItem<"id" | "name" | "tags">) => `[${analysis.id}] ${analysis.name}`;
-
   const oldIDList = new Set(oldList.map((x) => x.id));
   const configList: AnalysisListItem<"id" | "name" | "tags">[] = analysisList.filter((x) => oldIDList.has(x.id));
-
   const analysisOptions = analysisList.map((x) => ({
     title: getName(x),
     selected: configList.some((y) => y.id === x.id),
@@ -123,30 +92,21 @@ async function getAnalysisList(account: Account, oldList: NonNullable<IEnvironme
   const response = await chooseAnalysis(analysisOptions);
 
   const formatFileName = (x: string) => x.toLowerCase().replace(" ", "-");
-  const analysisResult: NonNullable<IEnvironment["analysisList"]> = response.map((x) => ({
+  return response.map((x) => ({
     fileName: formatFileName(x.name),
     name: x.name,
     id: x.id,
     ...oldList.find((old) => old.id === x.id),
-  }));
-
-  return analysisResult;
+  })) as NonNullable<IEnvironment["analysisList"]>;
 }
 
-/**
- * Searches for analysis scripts in the specified path and prompts the user to select a script for each analysis in the list.
- * @param analysisList - The list of analyses to associate with scripts.
- * @param analysisPath - The path to search for analysis scripts.
- * @returns A Promise that resolves to the updated analysis list with the selected script file names.
- */
-async function getAnalysisScripts(analysisList: NonNullable<IEnvironment["analysisList"]>, analysisPath: string) {
-  analysisPath = analysisPath.replace("./", "");
-  if (!analysisPath || !existsSync(analysisPath)) {
-    infoMSG(`Analysis folder not found at "${analysisPath || "(empty)"}"; skipping file matching. Edit tagoconfig.json or rerun init once the folder exists.`);
+async function getAnalysisScripts(analysisList: NonNullable<IEnvironment["analysisList"]>, analysisPathInput: string) {
+  const cleaned = analysisPathInput.replace("./", "");
+  if (!cleaned || !existsSync(cleaned)) {
+    infoMSG(`Analysis folder not found at "${cleaned || "(empty)"}"; skipping file matching.`);
     return analysisList;
   }
-  infoMSG(`Searching for files at ${analysisPath} and subfolders`);
-  let files: Choice[] = scanAnalysisFiles(analysisPath).map((x) => ({ title: x.filename, value: x.filename, description: x.relativePath }));
+  let files: Choice[] = scanAnalysisFiles(cleaned).map((x) => ({ title: x.filename, value: x.filename, description: x.relativePath }));
 
   for (const analysis of analysisList) {
     files = files.sort((a, b) =>
@@ -170,10 +130,9 @@ async function getAnalysisScripts(analysisList: NonNullable<IEnvironment["analys
 
     const file = files.find((x) => x.value === response);
     analysis.fileName = file?.title as string;
-    if (file?.description && file?.description?.length > 0) {
-      analysis.path = file?.description as string;
+    if (file?.description && file.description.length > 0) {
+      analysis.path = file.description;
     }
-
     const fileIndex = files.findIndex((x) => x.title === response);
     if (fileIndex !== -1) {
       files.splice(fileIndex, 1);
@@ -182,148 +141,277 @@ async function getAnalysisScripts(analysisList: NonNullable<IEnvironment["analys
   return analysisList;
 }
 
+const SCHEMA_STUB = JSON.stringify({ $schema: "https://github.com/tago-io/tagoio-cli/blob/master/docs/schema.json" });
+
+function bootstrapGlobalConfig(): void {
+  const globalRoot = globalConfigDir();
+  mkdirSync(globalRoot, { recursive: true, mode: 0o700 });
+  setScopeOverride("global");
+  const globalConfigPath = join(globalRoot, "tagoconfig.json");
+  if (!existsSync(globalConfigPath)) {
+    writeFileSync(globalConfigPath, SCHEMA_STUB, { encoding: "utf-8" });
+  }
+}
+
+function bootstrapLocalConfig(): void {
+  const localPath = join(process.cwd(), "tagoconfig.json");
+  if (!existsSync(localPath)) {
+    writeFileSync(localPath, SCHEMA_STUB, { encoding: "utf-8" });
+  }
+}
+
 /**
- * Starts the configuration process for a TagoIO environment.
- * @param environment The name of the environment to configure.
- * @param options The configuration options.
- * @param options.token The TagoIO token to use for authentication.
+ * @description Resolves the env name following the precedence:
+ *   1. --name flag, 2. positional argument, 3. default "dev"
+ * Emits a stderr note when the flag overrides the positional value.
  */
-async function startConfig(environment: string, { token, scope: scopeFlag }: ConfigOptions) {
-  // Resolve the target scope and make sure a tagoconfig.json exists at that
-  // scope so the rest of init can read/write it.
-  //
-  // Decision tree:
-  //   --scope global   → write to globalConfigDir()
-  //   --scope local    → write to ./tagoconfig.json
-  //   no flag, local config exists  → edit local
-  //   no flag, global config exists → edit global
-  //   no flag, neither exists       → prompt; "yes" creates global, "no" creates local
-  if (scopeFlag && scopeFlag !== "local" && scopeFlag !== "global") {
-    errorHandler(`Invalid --scope value: '${scopeFlag}'. Use 'local' or 'global'.`);
+function resolveEnvName(positional: string | undefined, flag: string | undefined): string {
+  if (flag && positional && flag !== positional) {
+    infoMSG(`--name overrides positional environment '${positional}'`);
   }
-  const SCHEMA_STUB = JSON.stringify({ $schema: "https://github.com/tago-io/tagoio-cli/blob/master/docs/schema.json" });
-  function bootstrapGlobalConfig(): void {
-    const globalRoot = globalConfigDir();
-    mkdirSync(globalRoot, { recursive: true, mode: 0o700 });
-    setScopeOverride("global");
-    const globalConfigPath = join(globalRoot, "tagoconfig.json");
-    if (!existsSync(globalConfigPath)) {
-      writeFileSync(globalConfigPath, SCHEMA_STUB, { encoding: "utf-8" });
-    }
+  return flag || positional || DEFAULT_ENV;
+}
+
+/**
+ * @description Step 1: existing-env handling. Either prompts to confirm
+ * overwrite, hard-errors under --no-input, or returns silently when nothing
+ * needs confirming.
+ */
+async function handleExistingEnv(state: InitState, envName: string, options: ConfigOptions): Promise<void> {
+  if (!state.envExists || options.force) {
+    return;
   }
-  function bootstrapLocalConfig(): void {
-    const localPath = join(process.cwd(), "tagoconfig.json");
-    if (!existsSync(localPath)) {
-      writeFileSync(localPath, SCHEMA_STUB, { encoding: "utf-8" });
-    }
+  if ((options.input === false)) {
+    errorHandler(
+      `Configuration for env '${envName}' already exists at ${state.scope.configPath}. Pass --force to overwrite, or pick a different env name.`,
+    );
   }
-  if (scopeFlag === "global") {
+  process.stderr.write(`\n${overwriteConfirmCopy(state, envName)}\n\n`);
+  const { confirm } = await prompts({
+    type: "confirm",
+    name: "confirm",
+    message: "Overwrite existing configuration?",
+    initial: false,
+  });
+  if (confirm !== true) {
+    infoMSG("Cancelled. No changes made.");
+    process.exit(0);
+  }
+}
+
+/**
+ * @description Resolves the target scope (Step 2). Honors --scope flag, then
+ * the existing-config decision tree from #4. Bootstraps the stub config file
+ * at the chosen scope so the rest of init has something to read/write.
+ */
+async function resolveTargetScope(options: ConfigOptions): Promise<void> {
+  if (options.scope === "global") {
     bootstrapGlobalConfig();
-  } else if (scopeFlag === "local") {
+    return;
+  }
+  if (options.scope === "local") {
     bootstrapLocalConfig();
-  } else if (!resolveScope().configExists) {
-    const { createGlobal } = await prompts({
-      type: "confirm",
-      name: "createGlobal",
-      message: `No tagoconfig.json found in this directory or globally. Create a global configuration at ${globalConfigDir()}/tagoconfig.json?`,
-      initial: false,
-    });
-    if (createGlobal) {
-      bootstrapGlobalConfig();
-    } else {
-      bootstrapLocalConfig();
-    }
+    return;
+  }
+  // No flag: rely on the resolver. If neither config exists, prompt (or
+  // default to local under --no-input).
+  const initial = detectInitState("__probe__");
+  if (initial.configExists) {
+    return;
+  }
+  if ((options.input === false)) {
+    bootstrapLocalConfig();
+    return;
+  }
+  const { createGlobal } = await prompts({
+    type: "confirm",
+    name: "createGlobal",
+    message: `No tagoconfig.json found in this directory or globally. Create a global configuration at ${globalConfigDir()}/tagoconfig.json?`,
+    initial: false,
+  });
+  if (createGlobal) {
+    bootstrapGlobalConfig();
+  } else {
+    bootstrapLocalConfig();
+  }
+}
+
+/**
+ * @description The init flow, restructured per clig.dev:
+ *   Step 0: pre-flight detection (silent)
+ *   Step 1: banner + overwrite confirm
+ *   Step 2: resolve inputs (flag → positional → existing → default)
+ *   Step 3: execute stages with [..]/[OK] progress markers
+ *   Step 4: state-change summary block
+ */
+async function startConfig(positional: string, options: ConfigOptions = {}): Promise<void> {
+  if (options.scope && options.scope !== "local" && options.scope !== "global") {
+    errorHandler(`Invalid --scope value: '${options.scope}'. Use 'local' or 'global'.`);
   }
 
-  const scope = resolveScope();
-  printScopeBanner(scope);
+  const envName = resolveEnvName(positional, options.name);
 
-  // Prompt user to enter environment name if not provided
-  if (!environment) {
-    ({ environment } = await prompts({
-      message: "Enter a name for this environment (e.g dev): ",
-      type: "text",
-      name: "environment",
-    }));
+  // Step 2 (early): bootstrap the chosen scope's tagoconfig.json. We need
+  // this before detectInitState() so envExists/tokenExists reflect the
+  // resolved scope and not the cwd-default fallback.
+  await resolveTargetScope(options);
+
+  // Step 0: pre-flight detection.
+  const state = detectInitState(envName);
+
+  // Step 1: banner + overwrite confirm.
+  process.stderr.write(`${banner(state.scope)}\n`);
+  await handleExistingEnv(state, envName, options);
+
+  // Step 2 (continued): resolve token. --no-input requires -t.
+  if ((options.input === false) && !options.token && !state.tokenExists) {
+    errorHandler("--no-input requires --token <token> when no existing lock file is on disk for this env.");
   }
 
-  // Get config file or return if not found
+  const filesWritten: { path: string; description: string }[] = [];
+
+  // Stage 1: project structure.
+  startStep("Creating project structure");
   const configFile = getConfigFile();
   if (!configFile) {
+    failStep("Creating project structure", "could not read or create tagoconfig.json");
+    return;
+  }
+  endStep(`Created ${state.scope.configPath}`);
+  filesWritten.push({ path: state.scope.configPath, description: "project configuration" });
+
+  // Stage 2 + 3: authenticate + persist credentials.
+  // --api-endpoint and --sse-endpoint must be passed together (or neither).
+  // TagoIO Deploy installations have non-derivable subdomains, so we never
+  // try to infer one from the other.
+  if ((options.apiEndpoint && !options.sseEndpoint) || (!options.apiEndpoint && options.sseEndpoint)) {
+    errorHandler("--api-endpoint and --sse-endpoint must both be set together (or neither).");
+  }
+
+  let token = options.token;
+  let tagoAPIURL = options.apiEndpoint;
+  let tagoSSEURL: string | undefined = options.sseEndpoint;
+
+  if (!token) {
+    token = readToken(envName);
+  }
+  if (!token) {
+    if ((options.input === false)) {
+      errorHandler("--no-input requires --token <token> for authentication.");
+    }
+    const data = await createEnvironmentToken(envName);
+    token = data?.profileToken;
+    tagoAPIURL = tagoAPIURL || data?.tagoDeployUrl;
+    tagoSSEURL = tagoSSEURL || data?.tagoDeploySse;
+  } else if (options.token) {
+    // Token came from the flag. Persist it to the lock file.
+    if (!(options.input === false) && !options.apiEndpoint) {
+      const urlConfig = await getTagoDeployURL();
+      tagoAPIURL = urlConfig?.urlAPI || tagoAPIURL;
+      tagoSSEURL = urlConfig?.urlSSE || tagoSSEURL;
+    }
+    writeToken(token, envName);
+    filesWritten.push({ path: `${state.scope.root}/.tago-lock.${envName}.lock`, description: "encrypted profile token" });
+  } else {
+    // Token already on disk; preserve URL settings from prior config.
+    tagoAPIURL = tagoAPIURL || configFile[envName]?.tagoAPIURL;
+    tagoSSEURL = tagoSSEURL || configFile[envName]?.tagoSSEURL;
+  }
+
+  if (!token) {
+    infoMSG("Cancelled. No changes made.");
     return;
   }
 
-  let tagoAPIURL, tagoSSEURL: string | undefined;
-
-  // Get token from file or prompt user to create one
-  if (!token) {
-    token = readToken(environment);
-    if (!token) {
-      const data = await createEnvironmentToken(environment);
-      token = data?.profileToken;
-      tagoAPIURL = data?.tagoDeployUrl;
-      tagoSSEURL = data?.tagoDeploySse;
-    } else {
-      tagoAPIURL = configFile[environment]?.tagoAPIURL;
-      tagoSSEURL = configFile[environment]?.tagoSSEURL;
-    }
-  } else {
-    const urlConfig = await getTagoDeployURL();
-    writeToken(token, environment);
-    tagoAPIURL = urlConfig?.urlAPI || "";
-    tagoSSEURL = urlConfig?.urlSSE || "";
-  }
-
-  // Analysis-related paths only apply to local scope. Global is for
-  // device/dashboard/profile work — no analysisList there.
-  if (scope.scope === "local") {
-    if (!configFile.analysisPath) {
+  // Local-only prompts for analysis paths.
+  if (state.scope.scope === "local") {
+    if (!configFile.analysisPath && !(options.input === false)) {
       configFile.analysisPath = await promptTextToEnter(`Enter the path of your ${kleur.cyan("analysis")} folder: `, "./src/analysis");
     }
-
-    if (!configFile.buildPath) {
+    if (!configFile.buildPath && !(options.input === false)) {
       configFile.buildPath = await promptTextToEnter(`Enter the path of your ${kleur.cyan("building")} folder (typescript): `, "./build");
     }
   }
 
-  // Return if token is not found
-  if (!token) {
-    return;
-  }
-
+  // API call to fetch profile metadata.
+  startStep("Authenticating with TagoIO");
   let region: GenericModuleParams["region"] = "us-e1";
   if (tagoAPIURL) {
-    region = {
-      api: tagoAPIURL || "",
-      sse: tagoSSEURL || "",
-    };
+    region = { api: tagoAPIURL, sse: tagoSSEURL || "" };
   }
-
-  // Get account info
   const account = new Account({ token, region });
-  const profile = await account.profiles.info("current");
-  const accountInfo = await account.info().catch(errorHandler);
-  if (!accountInfo) {
-    return;
+  let profile;
+  let accountInfo;
+  try {
+    profile = await account.profiles.info("current");
+    accountInfo = await account.info();
+  } catch (err) {
+    failStep("Authenticating with TagoIO", err);
+    process.exit(1);
   }
+  endStep(`Authenticated as ${profile.info.name}`);
 
-  // Create new environment object and write to config file. Local scope
-  // collects an analysisList; global scope omits the key entirely so the
-  // file shape stays a strict subset.
+  // Stage 4: build the new env block.
   const newEnv: IEnvironment = {
     id: profile.info.id,
     profileName: profile.info.name,
     email: accountInfo.email,
-    tagoSSEURL: tagoSSEURL,
-    tagoAPIURL: tagoAPIURL,
+    tagoSSEURL,
+    tagoAPIURL,
   };
-  if (scope.scope === "local") {
-    let analysisList = await getAnalysisList(account, configFile[environment]?.analysisList);
-    analysisList = await getAnalysisScripts(analysisList, configFile.analysisPath);
-    newEnv.analysisList = analysisList;
+  if (state.scope.scope === "local") {
+    if ((options.input === false)) {
+      // Non-interactive: preserve whatever analysisList is already on disk
+      // (re-init keeps it; fresh init starts empty). The user can populate it
+      // by editing tagoconfig.json or rerunning init interactively.
+      newEnv.analysisList = configFile[envName]?.analysisList ?? [];
+    } else {
+      let analysisList = await getAnalysisList(account, configFile[envName]?.analysisList);
+      analysisList = await getAnalysisScripts(analysisList, configFile.analysisPath);
+      newEnv.analysisList = analysisList;
+    }
   }
+  startStep("Setting up environment");
   writeToConfigFile(configFile);
-  writeConfigFileEnv(environment, newEnv);
+  writeConfigFileEnv(envName, newEnv);
+  endStep("Environment ready");
+  filesWritten.push({ path: state.scope.envFilePath, description: "active environment marker" });
+
+  // Step 4: state-change summary.
+  process.stderr.write(`\n${summaryBlock({
+    filesWritten,
+    scope: state.scope.scope,
+    envName,
+    profileName: profile.info.name,
+    apiEndpoint: tagoAPIURL || DEFAULT_API_ENDPOINT,
+    sseEndpoint: tagoSSEURL || DEFAULT_SSE_ENDPOINT,
+  })}\n`);
+}
+
+/**
+ * @description Helper used by interactive flows when no token is on disk and
+ * the user has not passed `-t`. Prompts for the login flow.
+ */
+async function createEnvironmentToken(environment: string) {
+  const { tryLogin } = await prompts({
+    message: "Do you want to login and create a profile-token now?",
+    type: "confirm",
+    name: "tryLogin",
+    hint: "Press N to enter a token later",
+  });
+  if (!tryLogin) {
+    return;
+  }
+  infoMSG(`You can create a token by running: ${highlightMSG("tagoio login")}`);
+
+  const opts = { token: undefined, tagoDeployUrl: undefined, tagoDeploySse: undefined };
+  await tagoLogin(environment, opts);
+
+  return {
+    profileToken: opts.token,
+    tagoDeployUrl: opts.tagoDeployUrl,
+    tagoDeploySse: opts.tagoDeploySse,
+  };
 }
 
 export { startConfig };

--- a/src/index.ts
+++ b/src/index.ts
@@ -74,21 +74,27 @@ function buildProgram(defaultEnv: string): Command {
   program
     .command("init")
     .description("create/update the config file for analysis in your current folder")
-    .argument("[environment]", "name of the environment.", defaultEnv || "dev")
+    .argument("[environment]", "name of the environment", defaultEnv || "dev")
     .option("-t, --token <profile-token>", "profile token of the environment and skip login step")
-    .option("--scope <scope>", "force a specific profile scope: 'local' (./tagoconfig.json) or 'global' (~/.config/tagoio/tagoconfig.json)")
+    .option("--name <name>", "env name (alias for [environment]); flag wins if both are passed")
+    .option("--scope <scope>", "force a specific profile scope: 'local' or 'global'")
+    .option("--api-endpoint <url>", "API endpoint URL (must be paired with --sse-endpoint)")
+    .option("--sse-endpoint <url>", "SSE endpoint URL (must be paired with --api-endpoint)")
+    .option("--no-input", "fail instead of prompting; --token required for authentication")
+    .option("--force", "skip the existing-configuration overwrite confirmation")
     .action(startConfig)
     .addHelpText(
       "after",
       `
-    Note: If you don't store credentials in this command, you must run tagoio login
+    Note: If you don't store credentials with -t, you must run tagoio login.
 
 Example:
     $ tagoio init
     $ tagoio init prod
     $ tagoio init -t eb8a1d42-0f28-4ee7-9862-839920eb1cb0
     $ tagoio init --scope global
-    $ tagoio init prod --scope global`,
+    $ tagoio init --no-input --name dev --scope local --api-endpoint https://api.tago.io --sse-endpoint https://sse.tago.io -t TOKEN
+    $ tagoio init prod --force`,
     );
 
   program

--- a/src/lib/__snapshots__/generate-man.test.ts.snap
+++ b/src/lib/__snapshots__/generate-man.test.ts.snap
@@ -35,18 +35,34 @@ create/update the config file for analysis in your current folder
 \\fB\\-t\\fR, \\fB\\-\\-token\\fR \\fI<profile\\-token>\\fR
 profile token of the environment and skip login step
 .TP
+\\fB\\-\\-name\\fR \\fI<name>\\fR
+env name (alias for [environment]); flag wins if both are passed
+.TP
 \\fB\\-\\-scope\\fR \\fI<scope>\\fR
-force a specific profile scope: 'local' (./tagoconfig.json) or 'global' (~/.config/tagoio/tagoconfig.json)
+force a specific profile scope: 'local' or 'global'
+.TP
+\\fB\\-\\-api\\-endpoint\\fR \\fI<url>\\fR
+API endpoint URL (must be paired with \\-\\-sse\\-endpoint)
+.TP
+\\fB\\-\\-sse\\-endpoint\\fR \\fI<url>\\fR
+SSE endpoint URL (must be paired with \\-\\-api\\-endpoint)
+.TP
+\\fB\\-\\-no\\-input\\fR
+fail instead of prompting; \\-\\-token required for authentication
+.TP
+\\fB\\-\\-force\\fR
+skip the existing\\-configuration overwrite confirmation
 .PP
 .nf
-    Note: If you don't store credentials in this command, you must run tagoio login
+    Note: If you don't store credentials with \\-t, you must run tagoio login.
 
 Example:
     $ tagoio init
     $ tagoio init prod
     $ tagoio init \\-t eb8a1d42\\-0f28\\-4ee7\\-9862\\-839920eb1cb0
     $ tagoio init \\-\\-scope global
-    $ tagoio init prod \\-\\-scope global
+    $ tagoio init \\-\\-no\\-input \\-\\-name dev \\-\\-scope local \\-\\-api\\-endpoint https://api.tago.io \\-\\-sse\\-endpoint https://sse.tago.io \\-t TOKEN
+    $ tagoio init prod \\-\\-force
 .fi
 .SS login [environment]
 login to your account and store profile_token in the tago\\-lock.

--- a/src/lib/__snapshots__/init-summary.test.ts.snap
+++ b/src/lib/__snapshots__/init-summary.test.ts.snap
@@ -1,0 +1,18 @@
+// Vitest Snapshot v1, https://vitest.dev/guide/snapshot.html
+
+exports[`init-summary > summaryBlock > formats files, scope, env name, profile name, and endpoint 1`] = `
+"---------------------------------------------------------
+Initialization complete.
+
+Created files:
+  ./tagoconfig.json      (project configuration)
+  ./.tago-lock.dev.lock  (encrypted profile token)
+
+Configuration:
+  Environment:  dev
+  Profile:      Tago Production
+  Scope:        local
+  API URL:      https://api.tago.io
+  SSE URL:      https://sse.tago.io
+---------------------------------------------------------"
+`;

--- a/src/lib/init-state.test.ts
+++ b/src/lib/init-state.test.ts
@@ -1,0 +1,103 @@
+import { afterEach, beforeEach, describe, expect, test, vi } from "vitest";
+
+import { ResolvedScope } from "./resolve-scope.js";
+
+const existsSyncMock = vi.fn<(path: string) => boolean>();
+const readFileSyncMock = vi.fn<(path: string, encoding: string) => string>();
+const resolveScopeMock = vi.fn<() => ResolvedScope>();
+
+vi.mock("node:fs", () => ({
+  existsSync: existsSyncMock,
+  readFileSync: readFileSyncMock,
+}));
+
+vi.mock("./resolve-scope.js", () => ({
+  resolveScope: () => resolveScopeMock(),
+}));
+
+const localScope: ResolvedScope = {
+  scope: "local",
+  root: "/repo",
+  configPath: "/repo/tagoconfig.json",
+  envFilePath: "/repo/.tagoio/personal.env",
+  configExists: true,
+};
+
+const globalScope: ResolvedScope = {
+  scope: "global",
+  root: "/home/user/.config/tagoio",
+  configPath: "/home/user/.config/tagoio/tagoconfig.json",
+  envFilePath: "/home/user/.config/tagoio/.tagoio/personal.env",
+  configExists: false,
+};
+
+describe("detectInitState", () => {
+  const originalIsTTY = process.stdin.isTTY;
+
+  beforeEach(() => {
+    existsSyncMock.mockReset().mockReturnValue(false);
+    readFileSyncMock.mockReset();
+    resolveScopeMock.mockReset().mockReturnValue(localScope);
+  });
+
+  afterEach(() => {
+    Object.defineProperty(process.stdin, "isTTY", { value: originalIsTTY, configurable: true });
+    vi.restoreAllMocks();
+  });
+
+  test("returns local scope, configExists=true, envExists=true when env block present", async () => {
+    readFileSyncMock.mockReturnValue(JSON.stringify({ dev: { id: "x" }, prod: { id: "y" } }));
+    existsSyncMock.mockImplementation((p) => p === "/repo/.tago-lock.dev.lock");
+    Object.defineProperty(process.stdin, "isTTY", { value: true, configurable: true });
+
+    const { detectInitState } = await import("./init-state.js");
+    const state = detectInitState("dev");
+
+    expect(state.scope.scope).toBe("local");
+    expect(state.configExists).toBe(true);
+    expect(state.envExists).toBe(true);
+    expect(state.tokenExists).toBe(true);
+    expect(state.isTTY).toBe(true);
+  });
+
+  test("envExists=false when the requested env is not in the config", async () => {
+    readFileSyncMock.mockReturnValue(JSON.stringify({ prod: { id: "y" } }));
+
+    const { detectInitState } = await import("./init-state.js");
+    expect(detectInitState("dev").envExists).toBe(false);
+  });
+
+  test("envExists=false on malformed config (parse error)", async () => {
+    readFileSyncMock.mockReturnValue("not-json {{");
+
+    const { detectInitState } = await import("./init-state.js");
+    expect(detectInitState("dev").envExists).toBe(false);
+  });
+
+  test("configExists=false propagates from resolveScope, envExists never set", async () => {
+    resolveScopeMock.mockReturnValue(globalScope);
+
+    const { detectInitState } = await import("./init-state.js");
+    const state = detectInitState("dev");
+    expect(state.configExists).toBe(false);
+    expect(state.envExists).toBe(false);
+    expect(readFileSyncMock).not.toHaveBeenCalled();
+  });
+
+  test("tokenExists reflects the .tago-lock.<env>.lock probe", async () => {
+    readFileSyncMock.mockReturnValue("{}");
+    existsSyncMock.mockImplementation((p) => p === "/repo/.tago-lock.staging.lock");
+
+    const { detectInitState } = await import("./init-state.js");
+    expect(detectInitState("staging").tokenExists).toBe(true);
+    expect(detectInitState("dev").tokenExists).toBe(false);
+  });
+
+  test("isTTY=false when stdin is not a terminal", async () => {
+    readFileSyncMock.mockReturnValue("{}");
+    Object.defineProperty(process.stdin, "isTTY", { value: undefined, configurable: true });
+
+    const { detectInitState } = await import("./init-state.js");
+    expect(detectInitState("dev").isTTY).toBe(false);
+  });
+});

--- a/src/lib/init-state.ts
+++ b/src/lib/init-state.ts
@@ -19,8 +19,8 @@ interface InitState {
  * @description Pre-flight detection (Step 0 of the clig.dev init flow).
  *
  * Reads the resolved scope and the on-disk state for the requested env name
- * so later steps can branch deterministically. No prompts, no API calls; a
- * handful of `existsSync` checks so it stays under 100ms even on slow disks.
+ * so later steps can branch deterministically. No prompts, no API calls; just
+ * a config read and a couple of `existsSync` checks.
  */
 function detectInitState(envName: string): InitState {
   const scope = resolveScope();

--- a/src/lib/init-state.ts
+++ b/src/lib/init-state.ts
@@ -1,0 +1,47 @@
+import { existsSync, readFileSync } from "node:fs";
+import path from "node:path";
+
+import { resolveScope, ResolvedScope } from "./resolve-scope.js";
+
+interface InitState {
+  scope: ResolvedScope;
+  /** True when stdin is an interactive terminal. Used by Step 2 to decide prompt vs flag-required. */
+  isTTY: boolean;
+  /** tagoconfig.json on disk at the resolved scope. */
+  configExists: boolean;
+  /** Env block already present in the resolved config. */
+  envExists: boolean;
+  /** Per-env lock file (.tago-lock.<envName>.lock) on disk. */
+  tokenExists: boolean;
+}
+
+/**
+ * @description Pre-flight detection (Step 0 of the clig.dev init flow).
+ *
+ * Reads the resolved scope and the on-disk state for the requested env name
+ * so later steps can branch deterministically. No prompts, no API calls; a
+ * handful of `existsSync` checks so it stays under 100ms even on slow disks.
+ */
+function detectInitState(envName: string): InitState {
+  const scope = resolveScope();
+  const configExists = scope.configExists;
+
+  let envExists = false;
+  if (configExists) {
+    // Malformed config → envExists stays false, the safe default for init.
+    try {
+      const raw = readFileSync(scope.configPath, "utf8");
+      const parsed = JSON.parse(raw);
+      envExists = typeof parsed === "object" && parsed !== null && envName in parsed && typeof parsed[envName] === "object";
+    } catch {
+      envExists = false;
+    }
+  }
+
+  const tokenExists = existsSync(path.join(scope.root, `.tago-lock.${envName}.lock`));
+  const isTTY = Boolean(process.stdin.isTTY);
+
+  return { scope, isTTY, configExists, envExists, tokenExists };
+}
+
+export { detectInitState, InitState };

--- a/src/lib/init-summary.test.ts
+++ b/src/lib/init-summary.test.ts
@@ -1,0 +1,161 @@
+import { afterEach, beforeEach, describe, expect, test, vi } from "vitest";
+
+import { InitState } from "./init-state.js";
+import { ResolvedScope } from "./resolve-scope.js";
+
+const localScope: ResolvedScope = {
+  scope: "local",
+  root: "/repo",
+  configPath: "/repo/tagoconfig.json",
+  envFilePath: "/repo/.tagoio/personal.env",
+  configExists: true,
+};
+
+const globalScope: ResolvedScope = {
+  scope: "global",
+  root: "/home/user/.config/tagoio",
+  configPath: "/home/user/.config/tagoio/tagoconfig.json",
+  envFilePath: "/home/user/.config/tagoio/.tagoio/personal.env",
+  configExists: true,
+};
+
+// kleur color codes muddy snapshot equality; strip them before assertion.
+// oxlint-disable-next-line no-control-regex
+const stripAnsi = (s: string) => s.replace(/\x1B\[[0-9;]*m/g, "");
+
+describe("init-summary", () => {
+  let stderrSpy: ReturnType<typeof vi.spyOn>;
+
+  beforeEach(() => {
+    stderrSpy = vi.spyOn(process.stderr, "write").mockImplementation(() => true);
+  });
+
+  afterEach(() => {
+    vi.restoreAllMocks();
+  });
+
+  describe("banner", () => {
+    test("names the resolved scope root", async () => {
+      const { banner } = await import("./init-summary.js");
+      expect(banner(localScope)).toBe("Initializing tagoio in /repo...");
+      expect(banner(globalScope)).toBe("Initializing tagoio in /home/user/.config/tagoio...");
+    });
+  });
+
+  describe("overwriteConfirmCopy", () => {
+    test("local scope names the global config dir as untouched", async () => {
+      const { overwriteConfirmCopy } = await import("./init-summary.js");
+      const state: InitState = { scope: localScope, isTTY: true, configExists: true, envExists: true, tokenExists: true };
+      const copy = overwriteConfirmCopy(state, "dev");
+      expect(copy).toContain("env 'dev'");
+      expect(copy).toContain("/repo/tagoconfig.json");
+      expect(copy).toContain("Reinitializing will overwrite");
+      expect(copy).toContain("global config located in ~/.config/tagoio/");
+    });
+
+    test("global scope names the local config in projects as untouched", async () => {
+      const { overwriteConfirmCopy } = await import("./init-summary.js");
+      const state: InitState = { scope: globalScope, isTTY: true, configExists: true, envExists: true, tokenExists: true };
+      const copy = overwriteConfirmCopy(state, "prod");
+      expect(copy).toContain("env 'prod'");
+      expect(copy).toContain("local config in any project directory");
+    });
+  });
+
+  describe("step markers", () => {
+    test("startStep writes [..] <label>... to stderr", async () => {
+      const { startStep } = await import("./init-summary.js");
+      startStep("Creating project structure");
+      const written = stripAnsi(stderrSpy.mock.calls[0][0] as string);
+      expect(written).toBe("[..] Creating project structure...\n");
+    });
+
+    test("endStep writes [OK] <label> to stderr", async () => {
+      const { endStep } = await import("./init-summary.js");
+      endStep("Created ./tagoconfig.json");
+      const written = stripAnsi(stderrSpy.mock.calls[0][0] as string);
+      expect(written).toBe("[OK] Created ./tagoconfig.json\n");
+    });
+
+    test("failStep writes [ERROR] <label>: <err.message> to stderr", async () => {
+      const { failStep } = await import("./init-summary.js");
+      failStep("Connecting", new Error("ENOTFOUND"));
+      const written = stripAnsi(stderrSpy.mock.calls[0][0] as string);
+      expect(written).toBe("[ERROR] Connecting: ENOTFOUND\n");
+    });
+
+    test("failStep without err prints just the label", async () => {
+      const { failStep } = await import("./init-summary.js");
+      failStep("Aborted");
+      const written = stripAnsi(stderrSpy.mock.calls[0][0] as string);
+      expect(written).toBe("[ERROR] Aborted\n");
+    });
+  });
+
+  describe("summaryBlock", () => {
+    test("formats files, scope, env name, profile name, and endpoint", async () => {
+      const { summaryBlock } = await import("./init-summary.js");
+      const out = summaryBlock({
+        filesWritten: [
+          { path: "./tagoconfig.json", description: "project configuration" },
+          { path: "./.tago-lock.dev.lock", description: "encrypted profile token" },
+        ],
+        scope: "local",
+        envName: "dev",
+        profileName: "Tago Production",
+        apiEndpoint: "https://api.tago.io",
+        sseEndpoint: "https://sse.tago.io",
+      });
+      expect(out).toMatchSnapshot();
+    });
+
+    test("renders '(no files were written)' when filesWritten is empty", async () => {
+      const { summaryBlock } = await import("./init-summary.js");
+      const out = summaryBlock({
+        filesWritten: [],
+        scope: "global",
+        envName: "prod",
+        profileName: "Tago",
+        apiEndpoint: "https://api.tago.io",
+        sseEndpoint: "https://sse.tago.io",
+      });
+      expect(out).toContain("(no files were written)");
+    });
+
+    test("env name and profile name are rendered as separate lines", async () => {
+      const { summaryBlock } = await import("./init-summary.js");
+      const out = summaryBlock({
+        filesWritten: [],
+        scope: "local",
+        envName: "smoke",
+        profileName: "Tago",
+        apiEndpoint: "https://api.tago.io",
+        sseEndpoint: "https://sse.tago.io",
+      });
+      expect(out).toContain("Environment:  smoke");
+      expect(out).toContain("Profile:      Tago");
+      expect(out).toContain("API URL:      https://api.tago.io");
+      expect(out).toContain("SSE URL:      https://sse.tago.io");
+    });
+
+    test("aligns description column when paths vary in length", async () => {
+      const { summaryBlock } = await import("./init-summary.js");
+      const out = summaryBlock({
+        filesWritten: [
+          { path: "/very/long/path/to/tagoconfig.json", description: "project configuration" },
+          { path: "/short.lock", description: "token" },
+        ],
+        scope: "local",
+        envName: "dev",
+        profileName: "Tago",
+        apiEndpoint: "https://api.tago.io",
+        sseEndpoint: "https://sse.tago.io",
+      });
+      // Both lines should have at least one space between path and "(".
+      const lines = out.split("\n").filter((l) => l.includes("(") && !l.startsWith("--"));
+      for (const line of lines) {
+        expect(line).toMatch(/\)\s*$|.+\s\(.+\)/);
+      }
+    });
+  });
+});

--- a/src/lib/init-summary.test.ts
+++ b/src/lib/init-summary.test.ts
@@ -3,6 +3,10 @@ import { afterEach, beforeEach, describe, expect, test, vi } from "vitest";
 import { InitState } from "./init-state.js";
 import { ResolvedScope } from "./resolve-scope.js";
 
+vi.mock("./resolve-scope.js", () => ({
+  globalConfigDir: () => "/home/user/.config/tagoio",
+}));
+
 const localScope: ResolvedScope = {
   scope: "local",
   root: "/repo",
@@ -50,7 +54,7 @@ describe("init-summary", () => {
       expect(copy).toContain("env 'dev'");
       expect(copy).toContain("/repo/tagoconfig.json");
       expect(copy).toContain("Reinitializing will overwrite");
-      expect(copy).toContain("global config located in ~/.config/tagoio/");
+      expect(copy).toContain("global config located in /home/user/.config/tagoio");
     });
 
     test("global scope names the local config in projects as untouched", async () => {
@@ -77,18 +81,26 @@ describe("init-summary", () => {
       expect(written).toBe("[OK] Created ./tagoconfig.json\n");
     });
 
-    test("failStep writes [ERROR] <label>: <err.message> to stderr", async () => {
+    test("failStep writes [ERROR] <label>: <err.message> to stderr then exits 1", async () => {
+      const exitSpy = vi.spyOn(process, "exit").mockImplementation(((code?: number) => {
+        throw new Error(`__exit:${code ?? 0}`);
+      }) as never);
       const { failStep } = await import("./init-summary.js");
-      failStep("Connecting", new Error("ENOTFOUND"));
+      expect(() => failStep("Connecting", new Error("ENOTFOUND"))).toThrow(/__exit:1/);
       const written = stripAnsi(stderrSpy.mock.calls[0][0] as string);
       expect(written).toBe("[ERROR] Connecting: ENOTFOUND\n");
+      expect(exitSpy).toHaveBeenCalledWith(1);
     });
 
-    test("failStep without err prints just the label", async () => {
+    test("failStep without err prints just the label then exits 1", async () => {
+      const exitSpy = vi.spyOn(process, "exit").mockImplementation(((code?: number) => {
+        throw new Error(`__exit:${code ?? 0}`);
+      }) as never);
       const { failStep } = await import("./init-summary.js");
-      failStep("Aborted");
+      expect(() => failStep("Aborted")).toThrow(/__exit:1/);
       const written = stripAnsi(stderrSpy.mock.calls[0][0] as string);
       expect(written).toBe("[ERROR] Aborted\n");
+      expect(exitSpy).toHaveBeenCalledWith(1);
     });
   });
 

--- a/src/lib/init-summary.ts
+++ b/src/lib/init-summary.ts
@@ -1,0 +1,97 @@
+import kleur from "kleur";
+
+import { InitState } from "./init-state.js";
+import { ResolvedScope } from "./resolve-scope.js";
+
+/**
+ * @description Banner printed at the top of `tagoio init` so the user knows
+ * what is about to happen and where it will land. Step 1 of the clig.dev flow.
+ */
+function banner(scope: ResolvedScope): string {
+  return `Initializing tagoio in ${scope.root}...`;
+}
+
+/**
+ * @description Multi-line block shown when an existing env would be overwritten.
+ * Followed by a confirm prompt in interactive mode, or a hard error under
+ * `--no-input`. Step 1 of the clig.dev flow.
+ */
+function overwriteConfirmCopy(state: InitState, envName: string): string {
+  const sibling = state.scope.scope === "local"
+    ? "Your global config located in ~/.config/tagoio/ will remain untouched."
+    : "Your local config in any project directory will remain untouched.";
+  return [
+    `An existing configuration was found for env '${envName}' at ${state.scope.configPath}.`,
+    "",
+    "Reinitializing will overwrite your current keys and config.",
+    sibling,
+  ].join("\n");
+}
+
+/**
+ * @description Running marker on stderr: `[..] <label>...`. Pair with
+ * `endStep` (success) or `failStep` (failure). Step 3 of the clig.dev flow.
+ */
+function startStep(label: string): void {
+  process.stderr.write(`[${kleur.cyan("..")}] ${label}...\n`);
+}
+
+/** Done marker on stderr: `[OK] <label>`. */
+function endStep(label: string): void {
+  process.stderr.write(`[${kleur.green("OK")}] ${label}\n`);
+}
+
+/** Failed marker on stderr: `[ERROR] <label>: <err>`. */
+function failStep(label: string, err?: unknown): void {
+  const suffix = err === undefined ? "" : `: ${err instanceof Error ? err.message : String(err)}`;
+  process.stderr.write(`[${kleur.red("ERROR")}] ${label}${suffix}\n`);
+}
+
+interface SummaryInput {
+  /** Files written or modified during execution, in the order they happened. */
+  filesWritten: { path: string; description: string }[];
+  scope: "local" | "global";
+  /** Env name (the key under which this profile is stored in tagoconfig.json). */
+  envName: string;
+  /** Display name of the TagoIO profile (`profileName` from the env block). */
+  profileName: string;
+  /** API endpoint URL for this env. */
+  apiEndpoint: string;
+  /** SSE endpoint URL for this env (always paired with apiEndpoint). */
+  sseEndpoint: string;
+}
+
+/**
+ * @description Final state-change summary block. Lists every file written
+ * along with the active scope, env name, profile name, and both endpoint
+ * URLs. Step 4 of the clig.dev flow.
+ *
+ * Pure formatter: no I/O. Snapshot-testable in isolation.
+ */
+function summaryBlock(input: SummaryInput): string {
+  const SEPARATOR = "---------------------------------------------------------";
+  // Path column auto-sizes to the longest path, with a 2-space gap before the
+  // (description) column so long paths don't run into the parenthesis.
+  const longest = Math.max(0, ...input.filesWritten.map((f) => f.path.length));
+  const fileLines = input.filesWritten.length > 0
+    ? input.filesWritten.map((f) => `  ${f.path.padEnd(longest)}  (${f.description})`).join("\n")
+    : "  (no files were written)";
+
+  return [
+    SEPARATOR,
+    "Initialization complete.",
+    "",
+    "Created files:",
+    fileLines,
+    "",
+    "Configuration:",
+    `  Environment:  ${input.envName}`,
+    `  Profile:      ${input.profileName}`,
+    `  Scope:        ${input.scope}`,
+    `  API URL:      ${input.apiEndpoint}`,
+    `  SSE URL:      ${input.sseEndpoint}`,
+    SEPARATOR,
+  ].join("\n");
+}
+
+export { banner, overwriteConfirmCopy, startStep, endStep, failStep, summaryBlock, SummaryInput };

--- a/src/lib/init-summary.ts
+++ b/src/lib/init-summary.ts
@@ -1,7 +1,7 @@
 import kleur from "kleur";
 
 import { InitState } from "./init-state.js";
-import { ResolvedScope } from "./resolve-scope.js";
+import { globalConfigDir, ResolvedScope } from "./resolve-scope.js";
 
 /**
  * @description Banner printed at the top of `tagoio init` so the user knows
@@ -18,7 +18,7 @@ function banner(scope: ResolvedScope): string {
  */
 function overwriteConfirmCopy(state: InitState, envName: string): string {
   const sibling = state.scope.scope === "local"
-    ? "Your global config located in ~/.config/tagoio/ will remain untouched."
+    ? `Your global config located in ${globalConfigDir()} will remain untouched.`
     : "Your local config in any project directory will remain untouched.";
   return [
     `An existing configuration was found for env '${envName}' at ${state.scope.configPath}.`,
@@ -42,9 +42,10 @@ function endStep(label: string): void {
 }
 
 /** Failed marker on stderr: `[ERROR] <label>: <err>`. */
-function failStep(label: string, err?: unknown): void {
+function failStep(label: string, err?: unknown): never {
   const suffix = err === undefined ? "" : `: ${err instanceof Error ? err.message : String(err)}`;
   process.stderr.write(`[${kleur.red("ERROR")}] ${label}${suffix}\n`);
+  process.exit(1);
 }
 
 interface SummaryInput {


### PR DESCRIPTION
Closes tago-io/project-sdk-and-tools#5.

## Problem

Today's `tagoio init` is a single linear prompt sequence: ask for credentials, write a config, exit. It does not announce what it is about to do, does not detect existing initialization, has no non-interactive mode, and gives no summary of what changed on disk. This is hostile to CI/CD, hostile to AI agents, and surprising to first-time users.

## Investigation

- The five [clig.dev](https://clig.dev/) steps map cleanly onto the existing init logic; most of the work is restructuring rather than new behavior.
- `prompts` returns `undefined` on cancel, so a single catch-all in the orchestrator handles Ctrl-C without exotic SIGINT plumbing.
- `--no-input` reduces to "no `prompts(...)` calls": auth must come from `-t` (or an existing lock file), and the analysis-selection prompts are skipped.
- TagoIO Deploy installations have non-derivable subdomains, so a single `--endpoint` flag is not enough — `--api-endpoint` and `--sse-endpoint` must be passed together (or neither).

## Solution

Three thin modules implement the flow:

- `src/lib/init-state.ts` — pre-flight `detectInitState(envName)` returning `{ scope, isTTY, configExists, envExists, tokenExists }`.
- `src/lib/init-summary.ts` — pure formatters for the banner, overwrite-confirm copy, `[..]/[OK]/[ERROR]` step markers, and the final summary block.
- `src/commands/start-config.ts` — orchestrator that runs the 5 steps in order and records every successful write into the summary.

### New CLI surface

| Flag | Purpose |
|---|---|
| \`--name <name>\` | env name (alias for the positional \`[environment]\`); flag wins on conflict |
| \`--api-endpoint <url>\` / \`--sse-endpoint <url>\` | both required together for self-hosted TagoIO Deploy |
| \`--no-input\` | refuses to prompt; needs \`-t\` (or an existing lock file) for auth |
| \`--force\` | skips the existing-config overwrite confirmation |

### Behavior changes

- Banner before any work: \`Initializing tagoio in <root>...\`
- Re-running init for an existing env triggers a confirm prompt (or hard-errors under \`--no-input\`); \`--force\` skips it.
- Each stage prints \`[..]\` running → \`[OK]\` done.
- Final summary lists every file created/modified plus environment, profile, scope, and both endpoint URLs.
- Cancelling any prompt prints \`[INFO] Cancelled. No changes made.\` and exits cleanly.

## Branch context

Branched off \`feat/cli-global-config\`; PR base is set there so the diff is scoped to the init rewrite only. Prior global/local-scope and man-page work lives in their own PRs.