### PR TITLE
fix(export): preserve custom widgets and analysis runtime on profile export

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -9,7 +9,7 @@
       "version": "3.2.0",
       "license": "ISC",
       "dependencies": {
-        "@tago-io/sdk": "^12.2.2",
+        "@tago-io/sdk": "^12.2.4",
         "async": "^3.2.6",
         "commander": "^14.0.3",
         "dotenv": "^17.4.2",
@@ -582,14 +582,14 @@
       }
     },
     "node_modules/@napi-rs/wasm-runtime": {
-      "version": "1.1.4",
-      "resolved": "https://registry.npmjs.org/@napi-rs/wasm-runtime/-/wasm-runtime-1.1.4.tgz",
-      "integrity": "sha512-3NQNNgA1YSlJb/kMH1ildASP9HW7/7kYnRI2szWJaofaS1hWmbGI4H+d3+22aGzXXN9IJ+n+GiFVcGipJP18ow==",
+      "version": "1.1.5",
+      "resolved": "https://registry.npmjs.org/@napi-rs/wasm-runtime/-/wasm-runtime-1.1.5.tgz",
+      "integrity": "sha512-AWPoBRJ9tsnVhor4sjO7rkni+7p+2IAEFj6cx06UgP10jkQHqay/36uRV/bFkgrh18D9vb4cr8Q0Pthskgzy+Q==",
       "dev": true,
       "license": "MIT",
       "optional": true,
       "dependencies": {
-        "@tybys/wasm-util": "^0.10.1"
+        "@tybys/wasm-util": "^0.10.2"
       },
       "funding": {
         "type": "github",
@@ -601,9 +601,9 @@
       }
     },
     "node_modules/@oxc-project/types": {
-      "version": "0.127.0",
-      "resolved": "https://registry.npmjs.org/@oxc-project/types/-/types-0.127.0.tgz",
-      "integrity": "sha512-aIYXQBo4lCbO4z0R3FHeucQHpF46l2LbMdxRvqvuRuW2OxdnSkcng5B8+K12spgLDj93rtN3+J2Vac/TIO+ciQ==",
+      "version": "0.133.0",
+      "resolved": "https://registry.npmjs.org/@oxc-project/types/-/types-0.133.0.tgz",
+      "integrity": "sha512-KzkdCd6Uxqnf6l3HOw1xfatAlUURA0g14cvBYFyJ5SaNOQbOUvBr9PKArcPcrNIeRsBdgcUzOGrhKveVpvOIGA==",
       "dev": true,
       "license": "MIT",
       "funding": {
@@ -737,9 +737,6 @@
         "arm64"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -757,9 +754,6 @@
         "arm64"
       ],
       "dev": true,
-      "libc": [
-        "musl"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -777,9 +771,6 @@
         "ppc64"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -797,9 +788,6 @@
         "riscv64"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -817,9 +805,6 @@
         "riscv64"
       ],
       "dev": true,
-      "libc": [
-        "musl"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -837,9 +822,6 @@
         "s390x"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -857,9 +839,6 @@
         "x64"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -877,9 +856,6 @@
         "x64"
       ],
       "dev": true,
-      "libc": [
-        "musl"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -1084,9 +1060,6 @@
         "arm64"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -1104,9 +1077,6 @@
         "arm64"
       ],
       "dev": true,
-      "libc": [
-        "musl"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -1124,9 +1094,6 @@
         "ppc64"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -1144,9 +1111,6 @@
         "riscv64"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -1164,9 +1128,6 @@
         "riscv64"
       ],
       "dev": true,
-      "libc": [
-        "musl"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -1184,9 +1145,6 @@
         "s390x"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -1204,9 +1162,6 @@
         "x64"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -1224,9 +1179,6 @@
         "x64"
       ],
       "dev": true,
-      "libc": [
-        "musl"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -1305,9 +1257,9 @@
       }
     },
     "node_modules/@rolldown/binding-android-arm64": {
-      "version": "1.0.0-rc.17",
-      "resolved": "https://registry.npmjs.org/@rolldown/binding-android-arm64/-/binding-android-arm64-1.0.0-rc.17.tgz",
-      "integrity": "sha512-s70pVGhw4zqGeFnXWvAzJDlvxhlRollagdCCKRgOsgUOH3N1l0LIxf83AtGzmb5SiVM4Hjl5HyarMRfdfj3DaQ==",
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-android-arm64/-/binding-android-arm64-1.0.3.tgz",
+      "integrity": "sha512-454rs7jHngixp/NMxd5srYD57OnzSlZ/eFTETjORQHLwJG1lRtmNOJcBerZlfu4GjKqeq8aCCIQrMdHyhI51Hw==",
       "cpu": [
         "arm64"
       ],
@@ -1322,9 +1274,9 @@
       }
     },
     "node_modules/@rolldown/binding-darwin-arm64": {
-      "version": "1.0.0-rc.17",
-      "resolved": "https://registry.npmjs.org/@rolldown/binding-darwin-arm64/-/binding-darwin-arm64-1.0.0-rc.17.tgz",
-      "integrity": "sha512-4ksWc9n0mhlZpZ9PMZgTGjeOPRu8MB1Z3Tz0Mo02eWfWCHMW1zN82Qz/pL/rC+yQa+8ZnutMF0JjJe7PjwasYw==",
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-darwin-arm64/-/binding-darwin-arm64-1.0.3.tgz",
+      "integrity": "sha512-PcAhP+ynjURNyy8SKGl5DQP94aGuB/7JrXJb/t7P+hanXvQVMWzUvRRhBAcg/lNRadBhoUPqSoP4xw5tR/KBEA==",
       "cpu": [
         "arm64"
       ],
@@ -1339,9 +1291,9 @@
       }
     },
     "node_modules/@rolldown/binding-darwin-x64": {
-      "version": "1.0.0-rc.17",
-      "resolved": "https://registry.npmjs.org/@rolldown/binding-darwin-x64/-/binding-darwin-x64-1.0.0-rc.17.tgz",
-      "integrity": "sha512-SUSDOI6WwUVNcWxd02QEBjLdY1VPHvlEkw6T/8nYG322iYWCTxRb1vzk4E+mWWYehTp7ERibq54LSJGjmouOsw==",
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-darwin-x64/-/binding-darwin-x64-1.0.3.tgz",
+      "integrity": "sha512-9YpfeUvSE2RS7wysJ81uOZkXJz7f7Q55H2Gvp3VEw/EsahqDtrphrZ0EwDLK5vvKOzaCrBsjF8JmnMLcUt78Gg==",
       "cpu": [
         "x64"
       ],
@@ -1356,9 +1308,9 @@
       }
     },
     "node_modules/@rolldown/binding-freebsd-x64": {
-      "version": "1.0.0-rc.17",
-      "resolved": "https://registry.npmjs.org/@rolldown/binding-freebsd-x64/-/binding-freebsd-x64-1.0.0-rc.17.tgz",
-      "integrity": "sha512-hwnz3nw9dbJ05EDO/PvcjaaewqqDy7Y1rn1UO81l8iIK1GjenME75dl16ajbvSSMfv66WXSRCYKIqfgq2KCfxw==",
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-freebsd-x64/-/binding-freebsd-x64-1.0.3.tgz",
+      "integrity": "sha512-yB1IlAsSNHncV6SCTL27/MVGR5htvQsoGxIv5KMGXALp+Ll1wYsn+x98M9MW7qa+NdSbvrrY7ANI4wLJ0n1e6g==",
       "cpu": [
         "x64"
       ],
@@ -1373,9 +1325,9 @@
       }
     },
     "node_modules/@rolldown/binding-linux-arm-gnueabihf": {
-      "version": "1.0.0-rc.17",
-      "resolved": "https://registry.npmjs.org/@rolldown/binding-linux-arm-gnueabihf/-/binding-linux-arm-gnueabihf-1.0.0-rc.17.tgz",
-      "integrity": "sha512-IS+W7epTcwANmFSQFrS1SivEXHtl1JtuQA9wlxrZTcNi6mx+FDOYrakGevvvTwgj2JvWiK8B29/qD9BELZPyXQ==",
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-linux-arm-gnueabihf/-/binding-linux-arm-gnueabihf-1.0.3.tgz",
+      "integrity": "sha512-Yi30IVAAfLUCy2MseFjbB1jAMDl1VMCAas5StnYp8da9+CKvMd2H2cbEjWcw5NPaPqzvYkVIaF1nNUG+b7u/sw==",
       "cpu": [
         "arm"
       ],
@@ -1390,16 +1342,13 @@
       }
     },
     "node_modules/@rolldown/binding-linux-arm64-gnu": {
-      "version": "1.0.0-rc.17",
-      "resolved": "https://registry.npmjs.org/@rolldown/binding-linux-arm64-gnu/-/binding-linux-arm64-gnu-1.0.0-rc.17.tgz",
-      "integrity": "sha512-e6usGaHKW5BMNZOymS1UcEYGowQMWcgZ71Z17Sl/h2+ZziNJ1a9n3Zvcz6LdRyIW5572wBCTH/Z+bKuZouGk9Q==",
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-linux-arm64-gnu/-/binding-linux-arm64-gnu-1.0.3.tgz",
+      "integrity": "sha512-jsO7R8To+AdlYgUmN5sHSCZbfhtMBkO0WUx8iORQnPcMMdgr7qM2DQmMwgabs3GhNztdmoKkMKQFHD6DTMCIQw==",
       "cpu": [
         "arm64"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -1410,16 +1359,13 @@
       }
     },
     "node_modules/@rolldown/binding-linux-arm64-musl": {
-      "version": "1.0.0-rc.17",
-      "resolved": "https://registry.npmjs.org/@rolldown/binding-linux-arm64-musl/-/binding-linux-arm64-musl-1.0.0-rc.17.tgz",
-      "integrity": "sha512-b/CgbwAJpmrRLp02RPfhbudf5tZnN9nsPWK82znefso832etkem8H7FSZwxrOI9djcdTP7U6YfNhbRnh7djErg==",
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-linux-arm64-musl/-/binding-linux-arm64-musl-1.0.3.tgz",
+      "integrity": "sha512-VWkUHwWriDciit80wleYwKILoR/KMvxh/IdwS/paX+ZgpuRpCrKLUdadJbc0NpBEiyhpYawsJ73j9aCvOH+f7Q==",
       "cpu": [
         "arm64"
       ],
       "dev": true,
-      "libc": [
-        "musl"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -1430,16 +1376,13 @@
       }
     },
     "node_modules/@rolldown/binding-linux-ppc64-gnu": {
-      "version": "1.0.0-rc.17",
-      "resolved": "https://registry.npmjs.org/@rolldown/binding-linux-ppc64-gnu/-/binding-linux-ppc64-gnu-1.0.0-rc.17.tgz",
-      "integrity": "sha512-4EII1iNGRUN5WwGbF/kOh/EIkoDN9HsupgLQoXfY+D1oyJm7/F4t5PYU5n8SWZgG0FEwakyM8pGgwcBYruGTlA==",
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-linux-ppc64-gnu/-/binding-linux-ppc64-gnu-1.0.3.tgz",
+      "integrity": "sha512-5f1laC0SlIR0yDbFCd8acUhvJIag6N3zC5P7oUPN6wX0aOma+uKJ0wBDH5aq7I1PVI2ttTlhJwzwRIBnLiSGEg==",
       "cpu": [
         "ppc64"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -1450,16 +1393,13 @@
       }
     },
     "node_modules/@rolldown/binding-linux-s390x-gnu": {
-      "version": "1.0.0-rc.17",
-      "resolved": "https://registry.npmjs.org/@rolldown/binding-linux-s390x-gnu/-/binding-linux-s390x-gnu-1.0.0-rc.17.tgz",
-      "integrity": "sha512-AH8oq3XqQo4IibpVXvPeLDI5pzkpYn0WiZAfT05kFzoJ6tQNzwRdDYQ45M8I/gslbodRZwW8uxLhbSBbkv96rA==",
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-linux-s390x-gnu/-/binding-linux-s390x-gnu-1.0.3.tgz",
+      "integrity": "sha512-Iq4ko0r4XsgbrF/LunNgHtAGLRRVE2kXonAXQ/MV0mC6jQpMOhW1SvtZja2EhC/kd05++bP78dsqBeIQyYJ6Yg==",
       "cpu": [
         "s390x"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -1470,16 +1410,13 @@
       }
     },
     "node_modules/@rolldown/binding-linux-x64-gnu": {
-      "version": "1.0.0-rc.17",
-      "resolved": "https://registry.npmjs.org/@rolldown/binding-linux-x64-gnu/-/binding-linux-x64-gnu-1.0.0-rc.17.tgz",
-      "integrity": "sha512-cLnjV3xfo7KslbU41Z7z8BH/E1y5mzUYzAqih1d1MDaIGZRCMqTijqLv76/P7fyHuvUcfGsIpqCdddbxLLK9rA==",
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-linux-x64-gnu/-/binding-linux-x64-gnu-1.0.3.tgz",
+      "integrity": "sha512-B8m6tD5+/N5FeNQFbKlLA/2yVq9ycQP1SeedyEYYKWBNR3ZQbkvIUcNnDNM03lO1l5F2roiiFJGgvoLLyZXtSg==",
       "cpu": [
         "x64"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -1490,16 +1427,13 @@
       }
     },
     "node_modules/@rolldown/binding-linux-x64-musl": {
-      "version": "1.0.0-rc.17",
-      "resolved": "https://registry.npmjs.org/@rolldown/binding-linux-x64-musl/-/binding-linux-x64-musl-1.0.0-rc.17.tgz",
-      "integrity": "sha512-0phclDw1spsL7dUB37sIARuis2tAgomCJXAHZlpt8PXZ4Ba0dRP1e+66lsRqrfhISeN9bEGNjQs+T/Fbd7oYGw==",
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-linux-x64-musl/-/binding-linux-x64-musl-1.0.3.tgz",
+      "integrity": "sha512-pSdpdUJHkuCxun9LE7jvgUB9qsRgaiyNNCX7m/AvHTcq67AiT/Yhoxvw5zPfhrM8k/BfP8ce/hMOpthKDpEUow==",
       "cpu": [
         "x64"
       ],
       "dev": true,
-      "libc": [
-        "musl"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -1510,9 +1444,9 @@
       }
     },
     "node_modules/@rolldown/binding-openharmony-arm64": {
-      "version": "1.0.0-rc.17",
-      "resolved": "https://registry.npmjs.org/@rolldown/binding-openharmony-arm64/-/binding-openharmony-arm64-1.0.0-rc.17.tgz",
-      "integrity": "sha512-0ag/hEgXOwgw4t8QyQvUCxvEg+V0KBcA6YuOx9g0r02MprutRF5dyljgm3EmR02O292UX7UeS6HzWHAl6KgyhA==",
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-openharmony-arm64/-/binding-openharmony-arm64-1.0.3.tgz",
+      "integrity": "sha512-OXXS3RKJgX2uLwM+gYyuH5omcH8fL1LJs96pZGgtetVCahON57+d4SJHzTgZiOjxgGkSnpXpOsWuPDGAKAigEg==",
       "cpu": [
         "arm64"
       ],
@@ -1527,9 +1461,9 @@
       }
     },
     "node_modules/@rolldown/binding-wasm32-wasi": {
-      "version": "1.0.0-rc.17",
-      "resolved": "https://registry.npmjs.org/@rolldown/binding-wasm32-wasi/-/binding-wasm32-wasi-1.0.0-rc.17.tgz",
-      "integrity": "sha512-LEXei6vo0E5wTGwpkJ4KoT3OZJRnglwldt5ziLzOlc6qqb55z4tWNq2A+PFqCJuvWWdP53CVhG1Z9NtToDPJrA==",
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-wasm32-wasi/-/binding-wasm32-wasi-1.0.3.tgz",
+      "integrity": "sha512-JTtb8BWFynicNSoPrehsCzBtOKjZ6jhMiPFEmOiuXg1Fl8dn2KHQob+GuPSGR0dryQa1PQJbzjF3dqO/whhjLg==",
       "cpu": [
         "wasm32"
       ],
@@ -1546,9 +1480,9 @@
       }
     },
     "node_modules/@rolldown/binding-win32-arm64-msvc": {
-      "version": "1.0.0-rc.17",
-      "resolved": "https://registry.npmjs.org/@rolldown/binding-win32-arm64-msvc/-/binding-win32-arm64-msvc-1.0.0-rc.17.tgz",
-      "integrity": "sha512-gUmyzBl3SPMa6hrqFUth9sVfcLBlYsbMzBx5PlexMroZStgzGqlZ26pYG89rBb45Mnia+oil6YAIFeEWGWhoZA==",
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-win32-arm64-msvc/-/binding-win32-arm64-msvc-1.0.3.tgz",
+      "integrity": "sha512-gEdFFEN70A/jxb2svrWsN3aDL7OUtmvlOy+6fa2jxG8K0wQ1ZbdeLGnidov6Yu5/733dI5ySfzFlQ/cb0bSz1g==",
       "cpu": [
         "arm64"
       ],
@@ -1563,9 +1497,9 @@
       }
     },
     "node_modules/@rolldown/binding-win32-x64-msvc": {
-      "version": "1.0.0-rc.17",
-      "resolved": "https://registry.npmjs.org/@rolldown/binding-win32-x64-msvc/-/binding-win32-x64-msvc-1.0.0-rc.17.tgz",
-      "integrity": "sha512-3hkiolcUAvPB9FLb3UZdfjVVNWherN1f/skkGWJP/fgSQhYUZpSIRr0/I8ZK9TkF3F7kxvJAk0+IcKvPHk9qQg==",
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-win32-x64-msvc/-/binding-win32-x64-msvc-1.0.3.tgz",
+      "integrity": "sha512-eXB7CHuaQdqmJcc3koCNtNPmT/bj2gc999kUFgBxG8Ac0NdgXc4rkCHhqrgrhN3zddvvvrgzj1e90SuSfmyIXA==",
       "cpu": [
         "x64"
       ],
@@ -1580,9 +1514,9 @@
       }
     },
     "node_modules/@rolldown/pluginutils": {
-      "version": "1.0.0-rc.17",
-      "resolved": "https://registry.npmjs.org/@rolldown/pluginutils/-/pluginutils-1.0.0-rc.17.tgz",
-      "integrity": "sha512-n8iosDOt6Ig1UhJ2AYqoIhHWh/isz0xpicHTzpKBeotdVsTEcxsSA/i3EVM7gQAj0rU27OLAxCjzlj15IWY7bg==",
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/@rolldown/pluginutils/-/pluginutils-1.0.1.tgz",
+      "integrity": "sha512-2j9bGt5Jh8hj+vPtgzPtl72j0yRxHAyumoo6TNfAjsLB04UtpSvPbPcDcBMxz7n+9CYB0c1GxQFxYRg2jimqGw==",
       "dev": true,
       "license": "MIT"
     },
@@ -1594,14 +1528,14 @@
       "license": "MIT"
     },
     "node_modules/@tago-io/sdk": {
-      "version": "12.2.2",
-      "resolved": "https://registry.npmjs.org/@tago-io/sdk/-/sdk-12.2.2.tgz",
-      "integrity": "sha512-/QgQRCexcHqwMHIdgs4cMJx5RIAN0ABAhV/PbbaYvBYB6hCe9W4vBE7PT0qOkxkgIs98jwJygngSXYluACp1ZQ==",
+      "version": "12.2.4",
+      "resolved": "https://registry.npmjs.org/@tago-io/sdk/-/sdk-12.2.4.tgz",
+      "integrity": "sha512-gPNyijzLcli5YPUqaMiH/P5q68XTHBE+y5f1pKIt4FHEwmAcHqv0RqyTlGuzisUJ/26iraj3LitWpdGMvvWxQQ==",
       "license": "Apache-2.0",
       "dependencies": {
         "nanoid": "5.1.5",
         "papaparse": "5.5.3",
-        "qs": "6.14.0"
+        "qs": "6.15.2"
       },
       "engines": {
         "node": ">=20.0.0"
@@ -1624,9 +1558,9 @@
       }
     },
     "node_modules/@tybys/wasm-util": {
-      "version": "0.10.1",
-      "resolved": "https://registry.npmjs.org/@tybys/wasm-util/-/wasm-util-0.10.1.tgz",
-      "integrity": "sha512-9tTaPJLSiejZKx+Bmog4uSubteqTvFrVrURwkmHixBo0G4seD0zUxp98E1DzUBJxLQ3NPwXrGKDiVjwx/DpPsg==",
+      "version": "0.10.2",
+      "resolved": "https://registry.npmjs.org/@tybys/wasm-util/-/wasm-util-0.10.2.tgz",
+      "integrity": "sha512-RoBvJ2X0wuKlWFIjrwffGw1IqZHKQqzIchKaadZZfnNpsAYp2mM0h36JtPCjNDAHGgYez/15uMBpfGwchhiMgg==",
       "dev": true,
       "license": "MIT",
       "optional": true,
@@ -2090,9 +2024,9 @@
       "license": "MIT"
     },
     "node_modules/es-object-atoms": {
-      "version": "1.1.1",
-      "resolved": "https://registry.npmjs.org/es-object-atoms/-/es-object-atoms-1.1.1.tgz",
-      "integrity": "sha512-FGgH2h8zKNim9ljj7dankFPcICIK9Cp5bm+c2gQSYePhpaG5+esrLODihIorn+Pe6FGJzWhXQotPv73jTaldXA==",
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/es-object-atoms/-/es-object-atoms-1.1.2.tgz",
+      "integrity": "sha512-HWcBoN6NileqtSydK2FqHbS/LoDd2pqrnQHLyJzBj4kOp/ky2MWMN694xOfkK8/SnUsW2DH7EfyVlydKCsm1Zw==",
       "license": "MIT",
       "dependencies": {
         "es-errors": "^1.3.0"
@@ -2340,9 +2274,9 @@
       }
     },
     "node_modules/hasown": {
-      "version": "2.0.3",
-      "resolved": "https://registry.npmjs.org/hasown/-/hasown-2.0.3.tgz",
-      "integrity": "sha512-ej4AhfhfL2Q2zpMmLo7U1Uv9+PyhIZpgQLGT1F9miIGmiCJIoCgSmczFdrc97mWT4kVY72KA+WnnhJ5pghSvSg==",
+      "version": "2.0.4",
+      "resolved": "https://registry.npmjs.org/hasown/-/hasown-2.0.4.tgz",
+      "integrity": "sha512-T2UbfbBEF32wiepXIsMlTW9+dDYC6wMh/t/vYA4tuOMKqWz/n3vr1NFSxQiyP+zk2mXsoMA/i/7qV6LKut1t1A==",
       "license": "MIT",
       "dependencies": {
         "function-bind": "^1.1.2"
@@ -2604,9 +2538,6 @@
         "arm64"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "MPL-2.0",
       "optional": true,
       "os": [
@@ -2628,9 +2559,6 @@
         "arm64"
       ],
       "dev": true,
-      "libc": [
-        "musl"
-      ],
       "license": "MPL-2.0",
       "optional": true,
       "os": [
@@ -2652,9 +2580,6 @@
         "x64"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "MPL-2.0",
       "optional": true,
       "os": [
@@ -2676,9 +2601,6 @@
         "x64"
       ],
       "dev": true,
-      "libc": [
-        "musl"
-      ],
       "license": "MPL-2.0",
       "optional": true,
       "os": [
@@ -3021,9 +2943,9 @@
       }
     },
     "node_modules/postcss": {
-      "version": "8.5.12",
-      "resolved": "https://registry.npmjs.org/postcss/-/postcss-8.5.12.tgz",
-      "integrity": "sha512-W62t/Se6rA0Az3DfCL0AqJwXuKwBeYg6nOaIgzP+xZ7N5BFCI7DYi1qs6ygUYT6rvfi6t9k65UMLJC+PHZpDAA==",
+      "version": "8.5.15",
+      "resolved": "https://registry.npmjs.org/postcss/-/postcss-8.5.15.tgz",
+      "integrity": "sha512-FfR8sjd4em2T6fb3I2MwAJU7HWVMr9zba+enmQeeWFfCbm+UOC/0X4DS8XtpUTMwWMGbjKYP7xjfNekzyGmB3A==",
       "dev": true,
       "funding": [
         {
@@ -3041,7 +2963,7 @@
       ],
       "license": "MIT",
       "dependencies": {
-        "nanoid": "^3.3.11",
+        "nanoid": "^3.3.12",
         "picocolors": "^1.1.1",
         "source-map-js": "^1.2.1"
       },
@@ -3050,9 +2972,9 @@
       }
     },
     "node_modules/postcss/node_modules/nanoid": {
-      "version": "3.3.11",
-      "resolved": "https://registry.npmjs.org/nanoid/-/nanoid-3.3.11.tgz",
-      "integrity": "sha512-N8SpfPUnUp1bK+PMYW8qSWdl9U+wwNWI4QKxOYDy9JAro3WMX7p2OeVRF9v+347pnakNevPmiHhNmZ2HbFA76w==",
+      "version": "3.3.13",
+      "resolved": "https://registry.npmjs.org/nanoid/-/nanoid-3.3.13.tgz",
+      "integrity": "sha512-sPdqC6ByMVVGvF1ynvvMo0/o+oD1VX7DaHhijt1bFgjvBkHBib4t49GoNDhf2NDta4oeUNlaGbSt5K7qjZ955Q==",
       "dev": true,
       "funding": [
         {
@@ -3097,9 +3019,9 @@
       }
     },
     "node_modules/qs": {
-      "version": "6.14.0",
-      "resolved": "https://registry.npmjs.org/qs/-/qs-6.14.0.tgz",
-      "integrity": "sha512-YWWTjgABSKcvs/nWBi9PycY/JiPJqOD4JA6o9Sej2AtvSGarXxKC3OQSk4pAarbdQlKAh5D4FCQkJNkW+GAn3w==",
+      "version": "6.15.2",
+      "resolved": "https://registry.npmjs.org/qs/-/qs-6.15.2.tgz",
+      "integrity": "sha512-Rzq0KEyX/w/tEybncDgdkZrJgVUsUMk3xjh3t5bv3S1HTAtg+uOYt72+ZfwiQwKdysThkTBdL/rTi6HDmX9Ddw==",
       "license": "BSD-3-Clause",
       "dependencies": {
         "side-channel": "^1.1.0"
@@ -3152,14 +3074,14 @@
       }
     },
     "node_modules/rolldown": {
-      "version": "1.0.0-rc.17",
-      "resolved": "https://registry.npmjs.org/rolldown/-/rolldown-1.0.0-rc.17.tgz",
-      "integrity": "sha512-ZrT53oAKrtA4+YtBWPQbtPOxIbVDbxT0orcYERKd63VJTF13zPcgXTvD4843L8pcsI7M6MErt8QtON6lrB9tyA==",
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/rolldown/-/rolldown-1.0.3.tgz",
+      "integrity": "sha512-i00lAJ2ks1BYr7rjNjKC7BcqAS7nVfiT3QX1SI5aY+AFHblCmaUf9OE9dbdzDvW6dJxbi2ZCZiy9v3CcwOiX3g==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@oxc-project/types": "=0.127.0",
-        "@rolldown/pluginutils": "1.0.0-rc.17"
+        "@oxc-project/types": "=0.133.0",
+        "@rolldown/pluginutils": "^1.0.0"
       },
       "bin": {
         "rolldown": "bin/cli.mjs"
@@ -3168,21 +3090,21 @@
         "node": "^20.19.0 || >=22.12.0"
       },
       "optionalDependencies": {
-        "@rolldown/binding-android-arm64": "1.0.0-rc.17",
-        "@rolldown/binding-darwin-arm64": "1.0.0-rc.17",
-        "@rolldown/binding-darwin-x64": "1.0.0-rc.17",
-        "@rolldown/binding-freebsd-x64": "1.0.0-rc.17",
-        "@rolldown/binding-linux-arm-gnueabihf": "1.0.0-rc.17",
-        "@rolldown/binding-linux-arm64-gnu": "1.0.0-rc.17",
-        "@rolldown/binding-linux-arm64-musl": "1.0.0-rc.17",
-        "@rolldown/binding-linux-ppc64-gnu": "1.0.0-rc.17",
-        "@rolldown/binding-linux-s390x-gnu": "1.0.0-rc.17",
-        "@rolldown/binding-linux-x64-gnu": "1.0.0-rc.17",
-        "@rolldown/binding-linux-x64-musl": "1.0.0-rc.17",
-        "@rolldown/binding-openharmony-arm64": "1.0.0-rc.17",
-        "@rolldown/binding-wasm32-wasi": "1.0.0-rc.17",
-        "@rolldown/binding-win32-arm64-msvc": "1.0.0-rc.17",
-        "@rolldown/binding-win32-x64-msvc": "1.0.0-rc.17"
+        "@rolldown/binding-android-arm64": "1.0.3",
+        "@rolldown/binding-darwin-arm64": "1.0.3",
+        "@rolldown/binding-darwin-x64": "1.0.3",
+        "@rolldown/binding-freebsd-x64": "1.0.3",
+        "@rolldown/binding-linux-arm-gnueabihf": "1.0.3",
+        "@rolldown/binding-linux-arm64-gnu": "1.0.3",
+        "@rolldown/binding-linux-arm64-musl": "1.0.3",
+        "@rolldown/binding-linux-ppc64-gnu": "1.0.3",
+        "@rolldown/binding-linux-s390x-gnu": "1.0.3",
+        "@rolldown/binding-linux-x64-gnu": "1.0.3",
+        "@rolldown/binding-linux-x64-musl": "1.0.3",
+        "@rolldown/binding-openharmony-arm64": "1.0.3",
+        "@rolldown/binding-wasm32-wasi": "1.0.3",
+        "@rolldown/binding-win32-arm64-msvc": "1.0.3",
+        "@rolldown/binding-win32-x64-msvc": "1.0.3"
       }
     },
     "node_modules/safe-buffer": {
@@ -3205,14 +3127,14 @@
       }
     },
     "node_modules/side-channel": {
-      "version": "1.1.0",
-      "resolved": "https://registry.npmjs.org/side-channel/-/side-channel-1.1.0.tgz",
-      "integrity": "sha512-ZX99e6tRweoUXqR+VBrslhda51Nh5MTQwou5tnUDgbtyM0dBgmhEDtWGP/xbKn6hqfPRHujUNwz5fy/wbbhnpw==",
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/side-channel/-/side-channel-1.1.1.tgz",
+      "integrity": "sha512-6x6dK6zJdpTzF4sQeNYxwtvBzf6Eg4GtlesS94HOvTudUeyK2WXAaIfmDgsyslYrRBeFIlsi54AYsFGUuhmvrQ==",
       "license": "MIT",
       "dependencies": {
         "es-errors": "^1.3.0",
-        "object-inspect": "^1.13.3",
-        "side-channel-list": "^1.0.0",
+        "object-inspect": "^1.13.4",
+        "side-channel-list": "^1.0.1",
         "side-channel-map": "^1.0.1",
         "side-channel-weakmap": "^1.0.2"
       },
@@ -3417,9 +3339,9 @@
       }
     },
     "node_modules/tinyglobby": {
-      "version": "0.2.16",
-      "resolved": "https://registry.npmjs.org/tinyglobby/-/tinyglobby-0.2.16.tgz",
-      "integrity": "sha512-pn99VhoACYR8nFHhxqix+uvsbXineAasWm5ojXoN8xEwK5Kd3/TrhNn1wByuD52UxWRLy8pu+kRMniEi6Eq9Zg==",
+      "version": "0.2.17",
+      "resolved": "https://registry.npmjs.org/tinyglobby/-/tinyglobby-0.2.17.tgz",
+      "integrity": "sha512-wXR/dYpcqKmfWpEdZjiKJOwCNFndD0DMnrW/cYjVGttEkBfVgcLFHoNrlj47mjOVic9yyNu65alsgF4NQyTa2g==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -3530,17 +3452,17 @@
       "license": "MIT"
     },
     "node_modules/vite": {
-      "version": "8.0.10",
-      "resolved": "https://registry.npmjs.org/vite/-/vite-8.0.10.tgz",
-      "integrity": "sha512-rZuUu9j6J5uotLDs+cAA4O5H4K1SfPliUlQwqa6YEwSrWDZzP4rhm00oJR5snMewjxF5V/K3D4kctsUTsIU9Mw==",
+      "version": "8.0.16",
+      "resolved": "https://registry.npmjs.org/vite/-/vite-8.0.16.tgz",
+      "integrity": "sha512-h9bXPmJichP5fLmVQo3PyaGSDE2n3aPuomeAlVRm0JLmt4rY6zmPKd59HYI4LNW8oTK7tlTsuC7l/m7awx9Jcw==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
         "lightningcss": "^1.32.0",
         "picomatch": "^4.0.4",
-        "postcss": "^8.5.10",
-        "rolldown": "1.0.0-rc.17",
-        "tinyglobby": "^0.2.16"
+        "postcss": "^8.5.15",
+        "rolldown": "1.0.3",
+        "tinyglobby": "^0.2.17"
       },
       "bin": {
         "vite": "bin/vite.js"
@@ -3556,7 +3478,7 @@
       },
       "peerDependencies": {
         "@types/node": "^20.19.0 || >=22.12.0",
-        "@vitejs/devtools": "^0.1.0",
+        "@vitejs/devtools": "^0.1.18",
         "esbuild": "^0.27.0 || ^0.28.0",
         "jiti": ">=1.21.0",
         "less": "^4.0.0",

--- a/package.json
+++ b/package.json
@@ -42,7 +42,7 @@
   "author": "TagoIO LLC",
   "license": "ISC",
   "dependencies": {
-    "@tago-io/sdk": "^12.2.2",
+    "@tago-io/sdk": "^12.2.4",
     "async": "^3.2.6",
     "commander": "^14.0.3",
     "dotenv": "^17.4.2",

--- a/src/commands/analysis/duplicate-analysis.ts
+++ b/src/commands/analysis/duplicate-analysis.ts
@@ -40,7 +40,7 @@ async function createNewAnalysis(account: Account, newAnalysisName: string, scri
 
   await account.analysis.uploadScript(new_analysis_id, {
     content: scriptBase64,
-    language: analysis.runtime || "node",
+    language: analysis.runtime || "node-legacy",
     name: "script.js",
   });
 

--- a/src/commands/profile/backup/resources/analysis.ts
+++ b/src/commands/profile/backup/resources/analysis.ts
@@ -33,14 +33,11 @@ async function readGzippedScript(filePath: string): Promise<string> {
 }
 
 /** Determines the script language based on the analysis runtime. */
-function getScriptLanguage(runtime?: string): "node" | "python" {
-  if (!runtime) {
-    return "node";
+function getScriptLanguage(runtime?: string): "node-legacy" | "python-legacy" {
+  if (runtime?.toLowerCase().includes("python")) {
+    return "python-legacy";
   }
-  if (runtime.toLowerCase().includes("python")) {
-    return "python";
-  }
-  return "node";
+  return "node-legacy";
 }
 
 /** Uploads script for an analysis if available. */
@@ -59,7 +56,7 @@ async function uploadAnalysisScript(
 
   const scriptContent = await readGzippedScript(scriptPath);
   const language = getScriptLanguage(runtime);
-  const fileName = language === "python" ? "script.py" : "script.js";
+  const fileName = language === "python-legacy" ? "script.py" : "script.js";
   const base64Content = Buffer.from(scriptContent).toString("base64");
 
   await resources.analysis.uploadScript(analysisId, {

--- a/src/commands/profile/export/export.test.ts
+++ b/src/commands/profile/export/export.test.ts
@@ -151,15 +151,10 @@ describe("startExport end-to-end", () => {
     let call = 0;
     profilesInfoMock.mockImplementation(async () => {
       call += 1;
-      return call === 1
-        ? { info: { name: "Export", id: "p-export" } }
-        : { info: { name: "Import", id: "p-import" } };
+      return call === 1 ? { info: { name: "Export", id: "p-export" } } : { info: { name: "Import", id: "p-import" } };
     });
 
-    prompts.inject([
-      ["devices", "analysis", "dashboards", "access", "run", "actions", "dictionaries"],
-      "my-tag",
-    ]);
+    prompts.inject([["devices", "analysis", "dashboards", "access", "run", "actions", "dictionaries"], "my-tag"]);
 
     const { startExport } = await import("./export.js");
     await startExport({
@@ -190,9 +185,7 @@ describe("startExport end-to-end", () => {
     let call = 0;
     profilesInfoMock.mockImplementation(async () => {
       call += 1;
-      return call === 1
-        ? { info: { name: "Export", id: "p-export" } }
-        : { info: { name: "Import", id: "p-import" } };
+      return call === 1 ? { info: { name: "Export", id: "p-export" } } : { info: { name: "Import", id: "p-import" } };
     });
 
     runInfoMock.mockReset();
@@ -207,7 +200,7 @@ describe("startExport end-to-end", () => {
         to: "dev",
         entity: [],
         setup: "",
-      })
+      }),
     ).rejects.toThrow(/RUN/);
   });
 
@@ -224,7 +217,7 @@ describe("startExport end-to-end", () => {
         to: "dev",
         entity: [],
         setup: "",
-      })
+      }),
     ).rejects.toThrow(/same profile/);
   });
 
@@ -232,9 +225,7 @@ describe("startExport end-to-end", () => {
     let call = 0;
     profilesInfoMock.mockImplementation(async () => {
       call += 1;
-      return call === 1
-        ? { info: { name: "Export", id: "p-export" } }
-        : { info: { name: "Import", id: "p-import" } };
+      return call === 1 ? { info: { name: "Export", id: "p-export" } } : { info: { name: "Import", id: "p-import" } };
     });
 
     const { confirmPrompt } = await import("../../../prompt/confirm.js");
@@ -249,7 +240,7 @@ describe("startExport end-to-end", () => {
         to: "dev",
         entity: [],
         setup: "",
-      })
+      }),
     ).rejects.toThrow(/Cancelled/);
   });
 
@@ -265,7 +256,7 @@ describe("startExport end-to-end", () => {
         to: "dev",
         entity: [],
         setup: "",
-      })
+      }),
     ).rejects.toThrow(/Export profile/);
   });
 
@@ -273,9 +264,7 @@ describe("startExport end-to-end", () => {
     let call = 0;
     profilesInfoMock.mockImplementation(async () => {
       call += 1;
-      return call === 1
-        ? { info: { name: "Export", id: "p-export" } }
-        : { info: { name: "Import", id: "p-import" } };
+      return call === 1 ? { info: { name: "Export", id: "p-export" } } : { info: { name: "Import", id: "p-import" } };
     });
 
     prompts.inject([["analysis"], "my-tag"]);
@@ -296,9 +285,7 @@ describe("startExport end-to-end", () => {
     let call = 0;
     profilesInfoMock.mockImplementation(async () => {
       call += 1;
-      return call === 1
-        ? { info: { name: "Export", id: "p-export" } }
-        : { info: { name: "Import", id: "p-import" } };
+      return call === 1 ? { info: { name: "Export", id: "p-export" } } : { info: { name: "Import", id: "p-import" } };
     });
 
     prompts.inject([["dashboards"], "my-tag"]);
@@ -320,9 +307,7 @@ describe("startExport end-to-end", () => {
     let call = 0;
     profilesInfoMock.mockImplementation(async () => {
       call += 1;
-      return call === 1
-        ? { info: { name: "Export", id: "p-export" } }
-        : { info: { name: "Import", id: "p-import" } };
+      return call === 1 ? { info: { name: "Export", id: "p-export" } } : { info: { name: "Import", id: "p-import" } };
     });
 
     prompts.inject([["access"], "my-tag"]);
@@ -343,9 +328,7 @@ describe("startExport end-to-end", () => {
     let call = 0;
     profilesInfoMock.mockImplementation(async () => {
       call += 1;
-      return call === 1
-        ? { info: { name: "Export", id: "p-export" } }
-        : { info: { name: "Import", id: "p-import" } };
+      return call === 1 ? { info: { name: "Export", id: "p-export" } } : { info: { name: "Import", id: "p-import" } };
     });
 
     prompts.inject([["actions"], "my-tag"]);
@@ -366,9 +349,7 @@ describe("startExport end-to-end", () => {
     let call = 0;
     profilesInfoMock.mockImplementation(async () => {
       call += 1;
-      return call === 1
-        ? { info: { name: "Export", id: "p-export" } }
-        : { info: { name: "Import", id: "p-import" } };
+      return call === 1 ? { info: { name: "Export", id: "p-export" } } : { info: { name: "Import", id: "p-import" } };
     });
 
     prompts.inject([["run"], "my-tag"]);
@@ -385,19 +366,47 @@ describe("startExport end-to-end", () => {
     expect(runButtonsExport).toHaveBeenCalled();
   });
 
+  test("prompts to skip custom widgets when dashboards are selected", async () => {
+    let call = 0;
+    profilesInfoMock.mockImplementation(async () => {
+      call += 1;
+      return call === 1 ? { info: { name: "Export", id: "p-export" } } : { info: { name: "Import", id: "p-import" } };
+    });
+
+    prompts.inject([["dashboards"], "my-tag"]);
+
+    const { startExport } = await import("./export.js");
+    await startExport({ from: "prod", to: "dev", entity: [], setup: "" });
+
+    const { confirmPrompt } = await import("../../../prompt/confirm.js");
+    expect(confirmPrompt).toHaveBeenCalledWith("Skip custom (iframe) widgets when exporting dashboards?");
+  });
+
+  test("does not prompt to skip custom widgets when dashboards are not selected", async () => {
+    let call = 0;
+    profilesInfoMock.mockImplementation(async () => {
+      call += 1;
+      return call === 1 ? { info: { name: "Export", id: "p-export" } } : { info: { name: "Import", id: "p-import" } };
+    });
+
+    prompts.inject([["devices"], "my-tag"]);
+
+    const { startExport } = await import("./export.js");
+    await startExport({ from: "prod", to: "dev", entity: [], setup: "" });
+
+    const { confirmPrompt } = await import("../../../prompt/confirm.js");
+    expect(confirmPrompt).not.toHaveBeenCalledWith("Skip custom (iframe) widgets when exporting dashboards?");
+  });
+
   test("resolves tokens via pickEnvironment when from/to are not provided", async () => {
     let call = 0;
     profilesInfoMock.mockImplementation(async () => {
       call += 1;
-      return call === 1
-        ? { info: { name: "Export", id: "p-export" } }
-        : { info: { name: "Import", id: "p-import" } };
+      return call === 1 ? { info: { name: "Export", id: "p-export" } } : { info: { name: "Import", id: "p-import" } };
     });
 
     const { pickEnvironment } = await import("../../../prompt/pick-environment.js");
-    (pickEnvironment as ReturnType<typeof vi.fn>)
-      .mockResolvedValueOnce("prod")
-      .mockResolvedValueOnce("dev");
+    (pickEnvironment as ReturnType<typeof vi.fn>).mockResolvedValueOnce("prod").mockResolvedValueOnce("dev");
 
     prompts.inject([["devices"], "tag"]);
 

--- a/src/commands/profile/export/export.ts
+++ b/src/commands/profile/export/export.ts
@@ -31,6 +31,8 @@ interface IExportOptions {
   setup: string;
   pick?: boolean;
   data?: string[] | true;
+  // Filled from an interactive prompt (not a CLI flag) and threaded into dashboardExport.
+  ignoreCustomWidgets?: boolean;
 }
 
 async function resolveTokens(userConfig: IExport, options: IExportOptions) {
@@ -148,6 +150,10 @@ async function collectParameters(options: IExportOptions) {
 
   userConfig.entities = await chooseEntities(options.entity);
   userConfig.export_tag = await enterExportTag(userConfig.export_tag);
+
+  if (userConfig.entities.includes("dashboards")) {
+    options.ignoreCustomWidgets = await confirmPrompt("Skip custom (iframe) widgets when exporting dashboards?");
+  }
 
   await confirmEnvironments(userConfig);
 

--- a/src/commands/profile/export/services/analysis-export.test.ts
+++ b/src/commands/profile/export/services/analysis-export.test.ts
@@ -87,10 +87,7 @@ describe("analysisExport", () => {
     const { analysisExport } = await import("./analysis-export.js");
     await analysisExport(account as never, importAccount as never, makeHolder());
 
-    expect(importAccount.analysis.uploadScript).toHaveBeenCalledWith(
-      "new-a",
-      expect.objectContaining({ language: "deno-rt2025" }),
-    );
+    expect(importAccount.analysis.uploadScript).toHaveBeenCalledWith("new-a", expect.objectContaining({ language: "deno-rt2025" }));
   });
 
   test("defaults to node-legacy runtime when the source has none", async () => {
@@ -111,17 +108,14 @@ describe("analysisExport", () => {
     const { analysisExport } = await import("./analysis-export.js");
     await analysisExport(account as never, importAccount as never, makeHolder());
 
-    expect(importAccount.analysis.uploadScript).toHaveBeenCalledWith(
-      "new-a",
-      expect.objectContaining({ language: "node-legacy" }),
-    );
+    // create gets the same defaulted runtime as uploadScript (parity), not a runtime-less object.
+    expect(importAccount.analysis.create).toHaveBeenCalledWith(expect.objectContaining({ runtime: "node-legacy" }));
+    expect(importAccount.analysis.uploadScript).toHaveBeenCalledWith("new-a", expect.objectContaining({ language: "node-legacy" }));
   });
 
   test("edits an existing analysis when target is found", async () => {
     account.analysis.list.mockResolvedValue([{ id: "a1", name: "A1", variables: [] }]);
-    importAccount.analysis.list.mockResolvedValue([
-      { id: "tgt-a", tags: [{ key: "export_id", value: "v1" }], variables: [] },
-    ]);
+    importAccount.analysis.list.mockResolvedValue([{ id: "tgt-a", tags: [{ key: "export_id", value: "v1" }], variables: [] }]);
     account.analysis.info.mockResolvedValue({
       id: "a1",
       name: "A1",
@@ -144,9 +138,7 @@ describe("analysisExport", () => {
   });
 
   test("prompts the user to resolve duplicate env variable values", async () => {
-    account.analysis.list.mockResolvedValue([
-      { id: "a1", name: "A1", variables: [{ key: "API_URL", value: "src.example" }] },
-    ]);
+    account.analysis.list.mockResolvedValue([{ id: "a1", name: "A1", variables: [{ key: "API_URL", value: "src.example" }] }]);
     importAccount.analysis.list.mockResolvedValue([
       {
         id: "tgt-a",

--- a/src/commands/profile/export/services/analysis-export.test.ts
+++ b/src/commands/profile/export/services/analysis-export.test.ts
@@ -68,6 +68,55 @@ describe("analysisExport", () => {
     expect(result.analysis["a1"]).toBe("new-a");
   });
 
+  test("preserves the source runtime when uploading the script", async () => {
+    account.analysis.list.mockResolvedValue([{ id: "a1", name: "A1", variables: [] }]);
+    importAccount.analysis.list.mockResolvedValue([]);
+    account.analysis.info.mockResolvedValue({
+      id: "a1",
+      name: "A1",
+      tags: [{ key: "export_id", value: "v1" }],
+      runtime: "deno-rt2025",
+      variables: [],
+    });
+    importAccount.analysis.create.mockResolvedValue({ id: "new-a" });
+    account.analysis.downloadScript.mockResolvedValue({ url: "http://script.url" });
+    importAccount.analysis.uploadScript.mockResolvedValue(undefined);
+    const zlib = await import("node:zlib");
+    fetchMock.mockResolvedValue(makeFetchArrayBufferResponse(zlib.gzipSync(Buffer.from("code"))));
+
+    const { analysisExport } = await import("./analysis-export.js");
+    await analysisExport(account as never, importAccount as never, makeHolder());
+
+    expect(importAccount.analysis.uploadScript).toHaveBeenCalledWith(
+      "new-a",
+      expect.objectContaining({ language: "deno-rt2025" }),
+    );
+  });
+
+  test("defaults to node-legacy runtime when the source has none", async () => {
+    account.analysis.list.mockResolvedValue([{ id: "a1", name: "A1", variables: [] }]);
+    importAccount.analysis.list.mockResolvedValue([]);
+    account.analysis.info.mockResolvedValue({
+      id: "a1",
+      name: "A1",
+      tags: [{ key: "export_id", value: "v1" }],
+      variables: [],
+    });
+    importAccount.analysis.create.mockResolvedValue({ id: "new-a" });
+    account.analysis.downloadScript.mockResolvedValue({ url: "http://script.url" });
+    importAccount.analysis.uploadScript.mockResolvedValue(undefined);
+    const zlib = await import("node:zlib");
+    fetchMock.mockResolvedValue(makeFetchArrayBufferResponse(zlib.gzipSync(Buffer.from("code"))));
+
+    const { analysisExport } = await import("./analysis-export.js");
+    await analysisExport(account as never, importAccount as never, makeHolder());
+
+    expect(importAccount.analysis.uploadScript).toHaveBeenCalledWith(
+      "new-a",
+      expect.objectContaining({ language: "node-legacy" }),
+    );
+  });
+
   test("edits an existing analysis when target is found", async () => {
     account.analysis.list.mockResolvedValue([{ id: "a1", name: "A1", variables: [] }]);
     importAccount.analysis.list.mockResolvedValue([
@@ -78,6 +127,7 @@ describe("analysisExport", () => {
       name: "A1",
       tags: [{ key: "export_id", value: "v1" }],
       active: true,
+      runtime: "deno-rt2025",
       variables: [],
     });
     importAccount.analysis.edit.mockResolvedValue(undefined);
@@ -89,7 +139,7 @@ describe("analysisExport", () => {
     const { analysisExport } = await import("./analysis-export.js");
     const holder = makeHolder();
     const result = await analysisExport(account as never, importAccount as never, holder);
-    expect(importAccount.analysis.edit).toHaveBeenCalled();
+    expect(importAccount.analysis.edit).toHaveBeenCalledWith("tgt-a", expect.objectContaining({ runtime: "deno-rt2025" }));
     expect(result.analysis["a1"]).toBe("tgt-a");
   });
 

--- a/src/commands/profile/export/services/analysis-export.ts
+++ b/src/commands/profile/export/services/analysis-export.ts
@@ -1,4 +1,4 @@
-import { Account, AnalysisListItem } from "@tago-io/sdk";
+import { Account, AnalysisListItem, RunTypeOptions } from "@tago-io/sdk";
 import prompts from "prompts";
 import zlib from "node:zlib";
 
@@ -110,6 +110,8 @@ async function analysisExport(account: Account, import_account: Account, export_
     ) || { id: null };
 
     const new_analysis = replaceObj(analysis, { ...export_holder.devices, ...export_holder.tokens });
+    // Propagate the source runtime as-is so it is not reset, defaulting to node-legacy when absent.
+    const runtime: RunTypeOptions = new_analysis.runtime ?? "node-legacy";
     if (!target_id) {
       ({ id: target_id } = await import_account.analysis.create(new_analysis));
     } else {
@@ -117,6 +119,7 @@ async function analysisExport(account: Account, import_account: Account, export_
         name: new_analysis.name,
         tags: new_analysis.tags,
         active: new_analysis.active,
+        runtime,
         variables: new_analysis.variables,
       });
       analysis_info.push({ id: target_id, variables: new_analysis.variables });
@@ -129,7 +132,11 @@ async function analysisExport(account: Account, import_account: Account, export_
     const scriptBuffer = Buffer.from(await scriptResponse.arrayBuffer());
     const script_base64 = zlib.gunzipSync(scriptBuffer).toString("base64");
 
-    await import_account.analysis.uploadScript(target_id, { content: script_base64, language: "node", name: "script.js" });
+    await import_account.analysis.uploadScript(target_id, {
+      content: script_base64,
+      language: runtime,
+      name: "script.js",
+    });
 
     export_holder.analysis[analysis_id] = target_id;
   }

--- a/src/commands/profile/export/services/analysis-export.ts
+++ b/src/commands/profile/export/services/analysis-export.ts
@@ -113,7 +113,7 @@ async function analysisExport(account: Account, import_account: Account, export_
     // Propagate the source runtime as-is so it is not reset, defaulting to node-legacy when absent.
     const runtime: RunTypeOptions = new_analysis.runtime ?? "node-legacy";
     if (!target_id) {
-      ({ id: target_id } = await import_account.analysis.create(new_analysis));
+      ({ id: target_id } = await import_account.analysis.create({ ...new_analysis, runtime }));
     } else {
       await import_account.analysis.edit(target_id, {
         name: new_analysis.name,

--- a/src/commands/profile/export/services/dashboards-export.test.ts
+++ b/src/commands/profile/export/services/dashboards-export.test.ts
@@ -18,7 +18,7 @@ vi.mock("./export-backup/export-backup.js", () => ({
 
 vi.mock("./widgets-export.js", () => ({
   insertWidgets: vi.fn(),
-  removeAllWidgets: vi.fn(),
+  removeAllWidgets: vi.fn().mockResolvedValue([]),
 }));
 
 describe("dashboardExport", () => {
@@ -39,12 +39,8 @@ describe("dashboardExport", () => {
   });
 
   test("returns the export_holder after processing a single dashboard with matching tag", async () => {
-    account.dashboards.list.mockResolvedValue([
-      { id: "dash-1", label: "Dash", tags: [{ key: "export_id", value: "my-dash" }] },
-    ]);
-    importAccount.dashboards.list.mockResolvedValue([
-      { id: "target-dash", label: "Dash", tags: [{ key: "export_id", value: "my-dash" }] },
-    ]);
+    account.dashboards.list.mockResolvedValue([{ id: "dash-1", label: "Dash", tags: [{ key: "export_id", value: "my-dash" }] }]);
+    importAccount.dashboards.list.mockResolvedValue([{ id: "target-dash", label: "Dash", tags: [{ key: "export_id", value: "my-dash" }] }]);
     account.dashboards.info.mockResolvedValue({
       id: "dash-1",
       label: "Dash",
@@ -62,20 +58,23 @@ describe("dashboardExport", () => {
     importAccount.dashboards.edit.mockResolvedValue(undefined);
 
     const { dashboardExport } = await import("./dashboards-export.js");
+    const { removeAllWidgets, insertWidgets } = await import("./widgets-export.js");
     const holder = makeHolder();
-    const result = await dashboardExport(
-      account as never,
-      importAccount as never,
-      holder,
-      { from: "a", to: "b", entity: [], setup: "" },
-    );
+    const result = await dashboardExport(account as never, importAccount as never, holder, {
+      from: "a",
+      to: "b",
+      entity: [],
+      setup: "",
+      ignoreCustomWidgets: true,
+    });
     expect(result).toBe(holder);
+    // removeAllWidgets receives the flag and its returned kept array is threaded into insertWidgets.
+    expect(removeAllWidgets).toHaveBeenCalledWith(expect.anything(), expect.anything(), true);
+    expect(insertWidgets).toHaveBeenCalledWith(expect.anything(), expect.anything(), expect.anything(), expect.anything(), expect.anything(), true, []);
   });
 
   test("creates a new dashboard when the import list has no match", async () => {
-    account.dashboards.list.mockResolvedValue([
-      { id: "dash-1", label: "Dash", tags: [{ key: "export_id", value: "only-in-source" }] },
-    ]);
+    account.dashboards.list.mockResolvedValue([{ id: "dash-1", label: "Dash", tags: [{ key: "export_id", value: "only-in-source" }] }]);
     importAccount.dashboards.list.mockResolvedValue([]);
     account.dashboards.info.mockResolvedValue({
       id: "dash-1",
@@ -97,12 +96,7 @@ describe("dashboardExport", () => {
     vi.useFakeTimers();
     const { dashboardExport } = await import("./dashboards-export.js");
     const holder = makeHolder();
-    const promise = dashboardExport(
-      account as never,
-      importAccount as never,
-      holder,
-      { from: "a", to: "b", entity: [], setup: "" },
-    );
+    const promise = dashboardExport(account as never, importAccount as never, holder, { from: "a", to: "b", entity: [], setup: "" });
     await vi.runAllTimersAsync();
     const result = await promise;
     vi.useRealTimers();
@@ -112,9 +106,7 @@ describe("dashboardExport", () => {
   });
 
   test("skips dashboards without the export tag", async () => {
-    account.dashboards.list.mockResolvedValue([
-      { id: "dash-1", label: "Dash", tags: [{ key: "other", value: "x" }] },
-    ]);
+    account.dashboards.list.mockResolvedValue([{ id: "dash-1", label: "Dash", tags: [{ key: "other", value: "x" }] }]);
     importAccount.dashboards.list.mockResolvedValue([]);
     account.dashboards.info.mockResolvedValue({
       id: "dash-1",
@@ -126,12 +118,7 @@ describe("dashboardExport", () => {
 
     const { dashboardExport } = await import("./dashboards-export.js");
     const holder = makeHolder();
-    await dashboardExport(
-      account as never,
-      importAccount as never,
-      holder,
-      { from: "a", to: "b", entity: [], setup: "" },
-    );
+    await dashboardExport(account as never, importAccount as never, holder, { from: "a", to: "b", entity: [], setup: "" });
     expect(importAccount.dashboards.create).not.toHaveBeenCalled();
     expect(holder.dashboards).toEqual({});
   });
@@ -164,12 +151,7 @@ describe("dashboardExport", () => {
     vi.useFakeTimers();
     const { dashboardExport } = await import("./dashboards-export.js");
     const holder = makeHolder();
-    const promise = dashboardExport(
-      account as never,
-      importAccount as never,
-      holder,
-      { from: "a", to: "b", entity: [], setup: "", pick: true },
-    );
+    const promise = dashboardExport(account as never, importAccount as never, holder, { from: "a", to: "b", entity: [], setup: "", pick: true });
     await vi.runAllTimersAsync();
     await promise;
     vi.useRealTimers();

--- a/src/commands/profile/export/services/dashboards-export.ts
+++ b/src/commands/profile/export/services/dashboards-export.ts
@@ -15,8 +15,9 @@ interface IQueue {
   export_holder: IExportHolder;
   importAccount: Account;
   exportAccount: Account;
+  ignoreCustomWidgets: boolean;
 }
-async function updateDashboard({ label, dash_id, import_list, export_holder, exportAccount, importAccount }: IQueue) {
+async function updateDashboard({ label, dash_id, import_list, export_holder, exportAccount, importAccount, ignoreCustomWidgets }: IQueue) {
   infoMSG(`Exporting dashboard ${label}...`);
   const exportDash = await exportAccount.dashboards.info(dash_id).catch((error) => {
     throw `Error on dashboard ${label} in export account: ${error}`;
@@ -34,9 +35,9 @@ async function updateDashboard({ label, dash_id, import_list, export_holder, exp
 
   await storeExportBackup("target", "dashboards", importDash);
 
-  await removeAllWidgets(importAccount, importDash).catch(errorHandler);
+  const keptIframes = await removeAllWidgets(importAccount, importDash, ignoreCustomWidgets).catch(errorHandler);
   importDash.arrangement = [];
-  await insertWidgets(exportAccount, importAccount, exportDash, importDash, export_holder).catch(errorHandler);
+  await insertWidgets(exportAccount, importAccount, exportDash, importDash, export_holder, ignoreCustomWidgets, keptIframes).catch(errorHandler);
   export_holder.dashboards[dash_id] = importDash.id;
 }
 
@@ -82,6 +83,7 @@ async function resolveDashboardTarget(
 
 async function dashboardExport(exportAccount: Account, importAccount: Account, export_holder: IExportHolder, options: IExportOptions) {
   infoMSG("Exporting dashboard: started");
+  const ignoreCustomWidgets = Boolean(options.ignoreCustomWidgets);
 
   let exportList = await exportAccount.dashboards.list({
     page: 1,
@@ -110,7 +112,7 @@ async function dashboardExport(exportAccount: Account, importAccount: Account, e
   dashboardQueue.error(errorHandler);
 
   for (const { id: dash_id, label } of exportList) {
-    void dashboardQueue.push({ dash_id, label, import_list, importAccount, export_holder, exportAccount }).catch(null);
+    void dashboardQueue.push({ dash_id, label, import_list, importAccount, export_holder, exportAccount, ignoreCustomWidgets }).catch(null);
   }
 
   await dashboardQueue.drain();

--- a/src/commands/profile/export/services/widgets-export.test.ts
+++ b/src/commands/profile/export/services/widgets-export.test.ts
@@ -97,6 +97,34 @@ describe("widgets-export", () => {
     expect(kept).toEqual([{ widget_id: "w-iframe", tab: "tab-1", x: 0, y: 0, width: 4, height: 4 }]);
   });
 
+  test("removeAllWidgets returns kept iframes in arrangement order despite out-of-order completion", async () => {
+    const deleteMock = vi.fn().mockResolvedValue(undefined);
+    // The first iframe's info resolves slower than the second, so without the index sort the kept
+    // array would come back reversed and insertWidgets would pair the wrong geometry.
+    const infoMock = vi.fn((_dashId: string, widgetId: string) => {
+      const delay = widgetId === "iframe-a" ? 100 : 10;
+      return new Promise((resolve) => setTimeout(() => resolve({ id: widgetId, type: "iframe" }), delay));
+    });
+    const importAccount = {
+      dashboards: { widgets: { delete: deleteMock, info: infoMock } },
+    } as never;
+
+    const dashboard = {
+      id: "d",
+      arrangement: [
+        { widget_id: "iframe-a", tab: "tab-1", x: 0, y: 0, width: 4, height: 4 },
+        { widget_id: "iframe-b", tab: "tab-1", x: 4, y: 0, width: 4, height: 4 },
+      ],
+    };
+
+    const { removeAllWidgets } = await import("./widgets-export.js");
+    const promise = removeAllWidgets(importAccount, dashboard as never, true);
+    await vi.runAllTimersAsync();
+    const kept = await promise;
+
+    expect(kept.map((k: { widget_id: string }) => k.widget_id)).toEqual(["iframe-a", "iframe-b"]);
+  });
+
   test("removeAllWidgets returns early when arrangement is empty", async () => {
     const deleteMock = vi.fn();
     const importAccount = {

--- a/src/commands/profile/export/services/widgets-export.test.ts
+++ b/src/commands/profile/export/services/widgets-export.test.ts
@@ -39,22 +39,19 @@ describe("widgets-export", () => {
       id: "dash-1",
       label: "Dash",
       arrangement: [{ widget_id: "w-1", tab: "tab-1" }],
-      tabs: [{ key: "tab-1", hidden: false }],
+      tabs: [{ key: "tab-1", type: "" }],
     };
     const target = { id: "dash-target" };
     const holder: IExportHolder = { analysis: {}, devices: {}, networks: {}, connectors: {}, dashboards: {} } as never;
 
     const { insertWidgets } = await import("./widgets-export.js");
-    const promise = insertWidgets(exportAccount, importAccount, dashboard as never, target as never, holder);
+    const promise = insertWidgets(exportAccount, importAccount, dashboard as never, target as never, holder, false);
     await vi.runAllTimersAsync();
     await promise;
 
     expect(widgetInfoMock).toHaveBeenCalledWith("dash-1", "w-1");
     expect(widgetCreateMock).toHaveBeenCalled();
-    expect(dashboardEditMock).toHaveBeenCalledWith(
-      "dash-target",
-      expect.objectContaining({ arrangement: expect.any(Array) })
-    );
+    expect(dashboardEditMock).toHaveBeenCalledWith("dash-target", expect.objectContaining({ arrangement: expect.any(Array) }));
   });
 
   test("removeAllWidgets deletes each widget in arrangement", async () => {
@@ -69,10 +66,35 @@ describe("widgets-export", () => {
     };
 
     const { removeAllWidgets } = await import("./widgets-export.js");
-    const promise = removeAllWidgets(importAccount, dashboard as never);
+    const promise = removeAllWidgets(importAccount, dashboard as never, false);
     await vi.runAllTimersAsync();
     await promise;
     expect(deleteMock).toHaveBeenCalledTimes(2);
+  });
+
+  test("removeAllWidgets keeps iframe widgets and returns them when ignoreCustomWidgets is true", async () => {
+    const deleteMock = vi.fn().mockResolvedValue(undefined);
+    const infoMock = vi.fn((_dashId: string, widgetId: string) => Promise.resolve({ id: widgetId, type: widgetId === "w-iframe" ? "iframe" : "display" }));
+    const importAccount = {
+      dashboards: { widgets: { delete: deleteMock, info: infoMock } },
+    } as never;
+
+    const dashboard = {
+      id: "d",
+      arrangement: [
+        { widget_id: "w-iframe", tab: "tab-1", x: 0, y: 0, width: 4, height: 4 },
+        { widget_id: "w-display", tab: "tab-1", x: 4, y: 0, width: 4, height: 4 },
+      ],
+    };
+
+    const { removeAllWidgets } = await import("./widgets-export.js");
+    const promise = removeAllWidgets(importAccount, dashboard as never, true);
+    await vi.runAllTimersAsync();
+    const kept = await promise;
+
+    expect(deleteMock).toHaveBeenCalledTimes(1);
+    expect(deleteMock).toHaveBeenCalledWith("d", "w-display");
+    expect(kept).toEqual([{ widget_id: "w-iframe", tab: "tab-1", x: 0, y: 0, width: 4, height: 4 }]);
   });
 
   test("removeAllWidgets returns early when arrangement is empty", async () => {
@@ -82,7 +104,7 @@ describe("widgets-export", () => {
     } as never;
 
     const { removeAllWidgets } = await import("./widgets-export.js");
-    await removeAllWidgets(importAccount, { id: "d", arrangement: [] } as never);
+    await removeAllWidgets(importAccount, { id: "d", arrangement: [] } as never, false);
     expect(deleteMock).not.toHaveBeenCalled();
   });
 
@@ -102,13 +124,13 @@ describe("widgets-export", () => {
       id: "dash-1",
       label: "Dash",
       arrangement: [{ widget_id: "ghost", tab: "tab-1" }],
-      tabs: [{ key: "tab-1", hidden: false }],
+      tabs: [{ key: "tab-1", type: "" }],
     };
     const target = { id: "dash-target" };
     const holder: IExportHolder = { analysis: {}, devices: {}, networks: {}, connectors: {}, dashboards: {} } as never;
 
     const { insertWidgets } = await import("./widgets-export.js");
-    const promise = insertWidgets(exportAccount, importAccount, dashboard as never, target as never, holder);
+    const promise = insertWidgets(exportAccount, importAccount, dashboard as never, target as never, holder, false);
     await vi.runAllTimersAsync();
     await promise;
 
@@ -116,9 +138,13 @@ describe("widgets-export", () => {
     expect(dashboardEditMock).toHaveBeenCalledWith("dash-target", { arrangement: [] });
   });
 
-  test("insertWidgets sorts hidden tabs to the end of the arrangement", async () => {
-    const widgetInfoMock = vi.fn().mockResolvedValue({ id: "w-1" });
-    const widgetCreateMock = vi.fn().mockResolvedValue({ widget: "w-new" });
+  test("insertWidgets creates hidden-tab widgets before visible-tab widgets", async () => {
+    const widgetInfoMock = vi.fn((_dashId: string, widgetId: string) => Promise.resolve({ id: widgetId }));
+    const createdOrder: string[] = [];
+    const widgetCreateMock = vi.fn((_targetId: string, widget: { id: string }) => {
+      createdOrder.push(widget.id);
+      return Promise.resolve({ widget: `${widget.id}-new` });
+    });
     const dashboardEditMock = vi.fn().mockResolvedValue(undefined);
 
     const exportAccount = { dashboards: { widgets: { info: widgetInfoMock } } } as never;
@@ -130,23 +156,24 @@ describe("widgets-export", () => {
       id: "dash-1",
       label: "Dash",
       arrangement: [
-        { widget_id: "w-1", tab: "tab-hidden" },
-        { widget_id: "w-2", tab: "tab-visible" },
+        { widget_id: "w-visible", tab: "tab-visible" },
+        { widget_id: "w-hidden", tab: "tab-hidden" },
       ],
       tabs: [
-        { key: "tab-hidden", hidden: true },
-        { key: "tab-visible", hidden: false },
+        { key: "tab-visible", type: "" },
+        { key: "tab-hidden", type: "hidden" },
       ],
     };
     const target = { id: "dash-target" };
     const holder: IExportHolder = { analysis: {}, devices: {}, networks: {}, connectors: {}, dashboards: {} } as never;
 
     const { insertWidgets } = await import("./widgets-export.js");
-    const promise = insertWidgets(exportAccount, importAccount, dashboard as never, target as never, holder);
+    const promise = insertWidgets(exportAccount, importAccount, dashboard as never, target as never, holder, false);
     await vi.runAllTimersAsync();
     await promise;
 
-    expect(widgetInfoMock).toHaveBeenCalled();
+    // The hidden-tab widget must be created first so header-button references resolve.
+    expect(createdOrder).toEqual(["w-hidden", "w-visible"]);
   });
 
   test("insertWidgets preserves widgets without a data array", async () => {
@@ -163,16 +190,171 @@ describe("widgets-export", () => {
       id: "dash-1",
       label: "Dash",
       arrangement: [{ widget_id: "w-1", tab: "tab-1" }],
-      tabs: [{ key: "tab-1", hidden: false }],
+      tabs: [{ key: "tab-1", type: "" }],
     };
     const target = { id: "dash-target" };
     const holder: IExportHolder = { analysis: {}, devices: {}, networks: {}, connectors: {}, dashboards: {} } as never;
 
     const { insertWidgets } = await import("./widgets-export.js");
-    const promise = insertWidgets(exportAccount, importAccount, dashboard as never, target as never, holder);
+    const promise = insertWidgets(exportAccount, importAccount, dashboard as never, target as never, holder, false);
     await vi.runAllTimersAsync();
     await promise;
 
     expect(widgetCreateMock).toHaveBeenCalled();
+  });
+
+  test("insertWidgets preserves the target iframe with the source geometry when ignoreCustomWidgets is true", async () => {
+    const widgetInfoMock = vi.fn((_dashId: string, widgetId: string) =>
+      Promise.resolve({ id: widgetId, type: widgetId === "w-iframe" ? "iframe" : "display" }),
+    );
+    const createdIds: string[] = [];
+    const widgetCreateMock = vi.fn((_targetId: string, widget: { id: string }) => {
+      createdIds.push(widget.id);
+      return Promise.resolve({ widget: `${widget.id}-new` });
+    });
+    const dashboardEditMock = vi.fn().mockResolvedValue(undefined);
+
+    const exportAccount = { dashboards: { widgets: { info: widgetInfoMock } } } as never;
+    const importAccount = {
+      dashboards: { widgets: { create: widgetCreateMock }, edit: dashboardEditMock },
+    } as never;
+
+    const dashboard = {
+      id: "dash-1",
+      label: "Dash",
+      arrangement: [
+        { widget_id: "w-iframe", tab: "tab-1", x: 2, y: 3, width: 6, height: 5 },
+        { widget_id: "w-display", tab: "tab-1", x: 0, y: 0, width: 4, height: 4 },
+      ],
+      tabs: [{ key: "tab-1", type: "" }],
+    };
+    const target = { id: "dash-target" };
+    const holder: IExportHolder = { analysis: {}, devices: {}, networks: {}, connectors: {}, dashboards: {} } as never;
+    // The kept target iframe entry uses the TARGET widget id but the source geometry should win.
+    const keptIframes = [{ widget_id: "target-iframe", tab: "tab-1", x: 99, y: 99, width: 1, height: 1 }];
+
+    const { insertWidgets } = await import("./widgets-export.js");
+    const promise = insertWidgets(exportAccount, importAccount, dashboard as never, target as never, holder, true, keptIframes as never);
+    await vi.runAllTimersAsync();
+    await promise;
+
+    // The iframe is not recreated, only the display is.
+    expect(createdIds).toEqual(["w-display"]);
+    // Arrangement keeps the target iframe id but the source position/size.
+    expect(dashboardEditMock).toHaveBeenCalledWith("dash-target", {
+      arrangement: [
+        { widget_id: "target-iframe", tab: "tab-1", x: 2, y: 3, width: 6, height: 5 },
+        { widget_id: "w-display-new", tab: "tab-1", x: 0, y: 0, width: 4, height: 4 },
+      ],
+    });
+  });
+
+  test("insertWidgets re-attaches kept iframes that have no source match", async () => {
+    const widgetInfoMock = vi.fn((_dashId: string, widgetId: string) => Promise.resolve({ id: widgetId, type: "display" }));
+    const widgetCreateMock = vi.fn((_targetId: string, widget: { id: string }) => Promise.resolve({ widget: `${widget.id}-new` }));
+    const dashboardEditMock = vi.fn().mockResolvedValue(undefined);
+
+    const exportAccount = { dashboards: { widgets: { info: widgetInfoMock } } } as never;
+    const importAccount = {
+      dashboards: { widgets: { create: widgetCreateMock }, edit: dashboardEditMock },
+    } as never;
+
+    // Source has only a display widget; the target keeps an extra iframe the source no longer has.
+    const dashboard = {
+      id: "dash-1",
+      label: "Dash",
+      arrangement: [{ widget_id: "w-display", tab: "tab-1", x: 0, y: 0, width: 4, height: 4 }],
+      tabs: [{ key: "tab-1", type: "" }],
+    };
+    const target = { id: "dash-target" };
+    const holder: IExportHolder = { analysis: {}, devices: {}, networks: {}, connectors: {}, dashboards: {} } as never;
+    const keptIframes = [{ widget_id: "orphan-iframe", tab: "tab-1", x: 8, y: 0, width: 4, height: 4 }];
+
+    const { insertWidgets } = await import("./widgets-export.js");
+    const promise = insertWidgets(exportAccount, importAccount, dashboard as never, target as never, holder, true, keptIframes as never);
+    await vi.runAllTimersAsync();
+    await promise;
+
+    // The orphaned kept iframe is appended with its own geometry so it is not lost.
+    expect(dashboardEditMock).toHaveBeenCalledWith("dash-target", {
+      arrangement: [
+        { widget_id: "w-display-new", tab: "tab-1", x: 0, y: 0, width: 4, height: 4 },
+        { widget_id: "orphan-iframe", tab: "tab-1", x: 8, y: 0, width: 4, height: 4 },
+      ],
+    });
+  });
+
+  test("insertWidgets exports iframe widgets when ignoreCustomWidgets is false", async () => {
+    const widgetInfoMock = vi.fn((_dashId: string, widgetId: string) =>
+      Promise.resolve({ id: widgetId, type: widgetId === "w-iframe" ? "iframe" : "display" }),
+    );
+    const createdIds: string[] = [];
+    const widgetCreateMock = vi.fn((_targetId: string, widget: { id: string }) => {
+      createdIds.push(widget.id);
+      return Promise.resolve({ widget: `${widget.id}-new` });
+    });
+    const dashboardEditMock = vi.fn().mockResolvedValue(undefined);
+
+    const exportAccount = { dashboards: { widgets: { info: widgetInfoMock } } } as never;
+    const importAccount = {
+      dashboards: { widgets: { create: widgetCreateMock }, edit: dashboardEditMock },
+    } as never;
+
+    const dashboard = {
+      id: "dash-1",
+      label: "Dash",
+      arrangement: [
+        { widget_id: "w-iframe", tab: "tab-1" },
+        { widget_id: "w-display", tab: "tab-1" },
+      ],
+      tabs: [{ key: "tab-1", type: "" }],
+    };
+    const target = { id: "dash-target" };
+    const holder: IExportHolder = { analysis: {}, devices: {}, networks: {}, connectors: {}, dashboards: {} } as never;
+
+    const { insertWidgets } = await import("./widgets-export.js");
+    const promise = insertWidgets(exportAccount, importAccount, dashboard as never, target as never, holder, false);
+    await vi.runAllTimersAsync();
+    await promise;
+
+    expect(createdIds).toEqual(["w-iframe", "w-display"]);
+  });
+
+  test("_sortHiddenWidgetsFirst orders hidden-tab widgets first (real org-management dashboard)", async () => {
+    const tabs = [
+      { key: "IujZ8pqDeqGR9wiAVYnqB", type: "" },
+      { key: "DWCnrWQFhX9Q7pFnLn_ct", type: "" },
+      { key: "lX97Kjts9qumnoOcA7G7Q", type: "" },
+      { key: "zZoK_1AQCt-iQiI29Yl7e", type: "hidden" },
+    ];
+    const arrangement = [
+      { tab: "IujZ8pqDeqGR9wiAVYnqB", widget_id: "6a32b0f1d3f020000ca5c208" },
+      { tab: "DWCnrWQFhX9Q7pFnLn_ct", widget_id: "6a32b0f3d5cee5000c54b207" },
+      { tab: "lX97Kjts9qumnoOcA7G7Q", widget_id: "6a32b0f4c4325f000c7358cc" },
+      { tab: "zZoK_1AQCt-iQiI29Yl7e", widget_id: "6a32b0f2c4325f000c735866" },
+      { tab: "zZoK_1AQCt-iQiI29Yl7e", widget_id: "6a32b0f2bf4706000c01817b" },
+    ];
+
+    const { _sortHiddenWidgetsFirst } = await import("./widgets-export.js");
+    const sorted = _sortHiddenWidgetsFirst(arrangement, tabs);
+
+    expect(sorted.slice(0, 2).map((x) => x.widget_id)).toEqual(["6a32b0f2c4325f000c735866", "6a32b0f2bf4706000c01817b"]);
+  });
+
+  test("_sortHiddenWidgetsFirst does not mutate the original arrangement", async () => {
+    const tabs = [
+      { key: "tab-visible", type: "" },
+      { key: "tab-hidden", type: "hidden" },
+    ];
+    const arrangement = [
+      { widget_id: "w-visible", tab: "tab-visible" },
+      { widget_id: "w-hidden", tab: "tab-hidden" },
+    ];
+    const original = [...arrangement];
+
+    const { _sortHiddenWidgetsFirst } = await import("./widgets-export.js");
+    _sortHiddenWidgetsFirst(arrangement, tabs);
+
+    expect(arrangement).toEqual(original);
   });
 });

--- a/src/commands/profile/export/services/widgets-export.ts
+++ b/src/commands/profile/export/services/widgets-export.ts
@@ -6,7 +6,7 @@ import { replaceObj } from "../../../../lib/replace-obj.js";
 import { IExportHolder } from "../types.js";
 import { storeExportBackup } from "./export-backup/export-backup.js";
 
-type DashboardTabs = { type?: string; key: string };
+type DashboardTabs = { type?: string; hidden?: boolean; key: string };
 type WidgetArrangement = { tab?: string | null };
 // The SDK declares Arrangement but does not export it; mirror the shape we read/write here.
 type Arrangement = { widget_id: string; x: number; y: number; width: number; height: number; tab?: string | null };
@@ -15,10 +15,11 @@ type Arrangement = { widget_id: string; x: number; y: number; width: number; hei
  * Orders widgets so the ones in hidden tabs are created first. A header button on a visible widget
  * references a hidden widget by id, and that reference is only remapped (via widgetIDMappings) if
  * the hidden widget already exists when the referencing widget is created. A tab is hidden when its
- * `type` is "hidden".
+ * `type` is "hidden" (current shape) or its legacy `hidden` flag is true — live payloads carry both
+ * consistently, so we accept either to stay robust against schema variation.
  */
 function _sortHiddenWidgetsFirst<T extends WidgetArrangement>(arrangement: T[], tabs: DashboardTabs[]) {
-  const hiddenTabKeys = new Set((tabs || []).filter((tab) => tab.type === "hidden").map((tab) => tab.key));
+  const hiddenTabKeys = new Set((tabs || []).filter((tab) => tab.type === "hidden" || tab.hidden === true).map((tab) => tab.key));
   const isHidden = (item: T) => Boolean(item.tab && hiddenTabKeys.has(item.tab));
   return [...arrangement].sort((a, b) => Number(isHidden(b)) - Number(isHidden(a)));
 }
@@ -130,16 +131,20 @@ async function insertWidgets(
  * the kept widgets so the caller can re-attach them to the rebuilt arrangement.
  */
 async function removeAllWidgets(importAccount: Account, dashboard: DashboardInfo, ignoreCustomWidgets: boolean) {
-  const kept: Arrangement[] = [];
   if (!dashboard.arrangement || dashboard.arrangement?.length === 0) {
-    return kept;
+    return [];
   }
 
-  const widgetQueue = queue(async (entry: Arrangement) => {
+  // The queue runs at concurrency 5, so callbacks finish out of order. Tag each kept entry with its
+  // arrangement index and sort by it before returning, so insertWidgets' positional shift() pairs
+  // each source iframe to the target iframe in arrangement order — not task-completion order.
+  const kept: { index: number; entry: Arrangement }[] = [];
+
+  const widgetQueue = queue(async ({ entry, index }: { entry: Arrangement; index: number }) => {
     if (ignoreCustomWidgets) {
       const info = await importAccount.dashboards.widgets.info(dashboard.id, entry.widget_id).catch(() => null);
       if (info?.type === "iframe") {
-        kept.push(entry);
+        kept.push({ index, entry });
         await new Promise((resolve) => setTimeout(resolve, 50)); // sleep
         return;
       }
@@ -149,12 +154,12 @@ async function removeAllWidgets(importAccount: Account, dashboard: DashboardInfo
   }, 5);
 
   widgetQueue.error(errorHandler);
-  for (const entry of dashboard.arrangement) {
-    widgetQueue.push(entry).catch(errorHandler);
+  for (let index = 0; index < dashboard.arrangement.length; index++) {
+    widgetQueue.push({ entry: dashboard.arrangement[index], index }).catch(errorHandler);
   }
 
   await widgetQueue.drain();
-  return kept;
+  return kept.sort((a, b) => a.index - b.index).map((k) => k.entry);
 }
 
 export { removeAllWidgets, insertWidgets };

--- a/src/commands/profile/export/services/widgets-export.ts
+++ b/src/commands/profile/export/services/widgets-export.ts
@@ -6,9 +6,47 @@ import { replaceObj } from "../../../../lib/replace-obj.js";
 import { IExportHolder } from "../types.js";
 import { storeExportBackup } from "./export-backup/export-backup.js";
 
-type DashboardTabs = { hidden: boolean; key: string };
+type DashboardTabs = { type?: string; key: string };
+type WidgetArrangement = { tab?: string | null };
+// The SDK declares Arrangement but does not export it; mirror the shape we read/write here.
+type Arrangement = { widget_id: string; x: number; y: number; width: number; height: number; tab?: string | null };
 
-async function insertWidgets(exportAccount: Account, importAccount: Account, dashboard: DashboardInfo, target: DashboardInfo, export_holder: IExportHolder) {
+/**
+ * Orders widgets so the ones in hidden tabs are created first. A header button on a visible widget
+ * references a hidden widget by id, and that reference is only remapped (via widgetIDMappings) if
+ * the hidden widget already exists when the referencing widget is created. A tab is hidden when its
+ * `type` is "hidden".
+ */
+function _sortHiddenWidgetsFirst<T extends WidgetArrangement>(arrangement: T[], tabs: DashboardTabs[]) {
+  const hiddenTabKeys = new Set((tabs || []).filter((tab) => tab.type === "hidden").map((tab) => tab.key));
+  const isHidden = (item: T) => Boolean(item.tab && hiddenTabKeys.has(item.tab));
+  return [...arrangement].sort((a, b) => Number(isHidden(b)) - Number(isHidden(a)));
+}
+
+/**
+ * Groups kept (preserved target) iframe arrangement entries by tab into FIFO queues. Source and
+ * target share tab keys (the export copies the source tabs), so the Nth source iframe in a tab is
+ * matched to the Nth kept target iframe in the same tab by shifting from its queue.
+ */
+function _groupKeptByTab(keptIframes: Arrangement[]) {
+  const byTab = new Map<string | null | undefined, Arrangement[]>();
+  for (const entry of keptIframes) {
+    const list = byTab.get(entry.tab) ?? [];
+    list.push(entry);
+    byTab.set(entry.tab, list);
+  }
+  return byTab;
+}
+
+async function insertWidgets(
+  exportAccount: Account,
+  importAccount: Account,
+  dashboard: DashboardInfo,
+  target: DashboardInfo,
+  export_holder: IExportHolder,
+  ignoreCustomWidgets: boolean,
+  keptIframes: Arrangement[] = [],
+) {
   const widget_ids = dashboard.arrangement?.map((x) => x.widget_id);
 
   const widgets: WidgetInfo[] = [];
@@ -32,17 +70,28 @@ async function insertWidgets(exportAccount: Account, importAccount: Account, das
 
   await newWidgetQueue.drain();
 
-  const hiddenTabKeys = new Set(dashboard.tabs.filter((tab: DashboardTabs) => !tab.hidden).map((tab: DashboardTabs) => tab.key));
   if (!dashboard.arrangement) {
     return;
   }
-  const arrangement = dashboard.arrangement.sort((a) => (a.tab && hiddenTabKeys.has(a.tab) ? 1 : -1));
+  const arrangement = _sortHiddenWidgetsFirst(dashboard.arrangement, dashboard.tabs as unknown as DashboardTabs[]);
 
-  const new_arrangement: any = [];
+  const new_arrangement: Arrangement[] = [];
   const widgetIDMappings: { [key: string]: string } = {};
+  const keptByTab = _groupKeptByTab(keptIframes);
   for (const widget_arrangement of arrangement) {
     const widget = widgets.find((wdgt) => widget_arrangement.widget_id === wdgt.id);
     if (!widget || !widget.id) {
+      continue;
+    }
+
+    // Custom widgets (type "iframe") carry source-only data (Files URL, analysis tokens) that the
+    // ID remap cannot resolve. Instead of recreating from source, keep the target's reconfigured
+    // widget and re-attach it with the source geometry (position/size). Matched by tab order.
+    if (ignoreCustomWidgets && widget.type === "iframe") {
+      const kept = keptByTab.get(widget_arrangement.tab)?.shift();
+      if (kept) {
+        new_arrangement.push({ ...widget_arrangement, widget_id: kept.widget_id });
+      }
       continue;
     }
 
@@ -65,26 +114,48 @@ async function insertWidgets(exportAccount: Account, importAccount: Account, das
     await new Promise((resolve) => setTimeout(resolve, 500)); // ? Prevent RPM limit issues
   }
 
+  // Kept iframes with no matching source widget (target has more iframes than source) would be
+  // orphaned by the arrangement overwrite below. Re-attach them with their own target geometry.
+  for (const leftover of keptByTab.values()) {
+    new_arrangement.push(...leftover);
+  }
+
   await importAccount.dashboards.edit(target.id, { arrangement: new_arrangement });
 }
 
-async function removeAllWidgets(importAccount: Account, dashboard: DashboardInfo) {
+/**
+ * Deletes the target dashboard's widgets before they are recreated from the source. When
+ * `ignoreCustomWidgets` is on, custom (iframe) widgets are kept instead of deleted so the user's
+ * manual reconfiguration (Files URL, analysis tokens) survives. Returns the arrangement entries of
+ * the kept widgets so the caller can re-attach them to the rebuilt arrangement.
+ */
+async function removeAllWidgets(importAccount: Account, dashboard: DashboardInfo, ignoreCustomWidgets: boolean) {
+  const kept: Arrangement[] = [];
   if (!dashboard.arrangement || dashboard.arrangement?.length === 0) {
-    return;
+    return kept;
   }
 
-  const widgetQueue = queue(async (widget_id: string) => {
-    await importAccount.dashboards.widgets.delete(dashboard.id, widget_id).catch(() => null);
+  const widgetQueue = queue(async (entry: Arrangement) => {
+    if (ignoreCustomWidgets) {
+      const info = await importAccount.dashboards.widgets.info(dashboard.id, entry.widget_id).catch(() => null);
+      if (info?.type === "iframe") {
+        kept.push(entry);
+        await new Promise((resolve) => setTimeout(resolve, 50)); // sleep
+        return;
+      }
+    }
+    await importAccount.dashboards.widgets.delete(dashboard.id, entry.widget_id).catch(() => null);
     await new Promise((resolve) => setTimeout(resolve, 50)); // sleep
-    return;
   }, 5);
 
   widgetQueue.error(errorHandler);
-  for (const x of dashboard.arrangement) {
-    widgetQueue.push(x.widget_id).catch(errorHandler);
+  for (const entry of dashboard.arrangement) {
+    widgetQueue.push(entry).catch(errorHandler);
   }
 
   await widgetQueue.drain();
+  return kept;
 }
 
 export { removeAllWidgets, insertWidgets };
+export { _sortHiddenWidgetsFirst }; // exported for testing purposes

--- a/src/commands/profile/index.ts
+++ b/src/commands/profile/index.ts
@@ -45,6 +45,7 @@ function profileCommands(program: Command, _defaultEnvironment: string) {
     ${kleur.bold("Entities Export")}:
     - ${highlightMSG("dashboards")}: Export the dashboard label, blueprint devices, tabs, tags and widgets of the dashboard.
       ${kleur.bold("Note")}: To export the dashboards while preserving the relationship between Devices/Analysis, ensure they have the export_id tag or any other tag you choose.
+      ${kleur.bold("Note")}: When exporting dashboards you are asked whether to skip custom (iframe) widgets, which carry source-only data (Files URL, parameters and others) and are best reconfigured manually on the target.
     - ${highlightMSG("devices")}: Export the devices configuration. Use --data to also copy device data: --data copies all variables, --data var1 var2 copies only specified variables.
                If you are using device-tokens in Environment Variables or tags, you want to include the device in the export command.
     - ${highlightMSG("analysis")}: Export the analysis name, code, tags, mode and timeout settings.

--- a/src/lib/__snapshots__/generate-man.test.ts.snap
+++ b/src/lib/__snapshots__/generate-man.test.ts.snap
@@ -913,6 +913,7 @@ copy device data with specified variable names (omit names to copy all)
     Entities Export:
     \\- dashboards: Export the dashboard label, blueprint devices, tabs, tags and widgets of the dashboard.
       Note: To export the dashboards while preserving the relationship between Devices/Analysis, ensure they have the export_id tag or any other tag you choose.
+      Note: When exporting dashboards you are asked whether to skip custom (iframe) widgets, which carry source\\-only data (Files URL, parameters and others) and are best reconfigured manually on the target.
     \\- devices: Export the devices configuration. Use \\-\\-data to also copy device data: \\-\\-data copies all variables, \\-\\-data var1 var2 copies only specified variables.
                If you are using device\\-tokens in Environment Variables or tags, you want to include the device in the export command.
     \\- analysis: Export the analysis name, code, tags, mode and timeout settings.


### PR DESCRIPTION
## Summary

Three fixes for the `tagoio export` command, covering dashboard and analysis export.

### 1. Create hidden-tab widgets first on dashboard export

When a dashboard was exported for the first time, the widgets were created in arrangement order. A header button on a visible widget can reference a widget that lives in a hidden tab, and that reference only resolves if the hidden widget already exists when the button is created. Because hidden-tab widgets were sometimes created last, those header buttons did nothing when the user clicked them.

Hidden-tab widgets are now created before the visible ones, so the references resolve correctly.

### 2. Skip custom widgets on dashboard export

A custom (iframe) widget points to data that only exists in the source profile: its URL is a file hosted in the source profile's Files, and its configuration parameters can hold IDs or an analysis token. The export copied these values straight from the source every time, so the target widget kept pointing at the source. The clearest example is a parameter holding an analysis token used to upload files: after the export, uploads landed in the source profile's Files instead of the target's.

When `dashboards` is selected, the export now asks whether to skip custom widgets. When skipping, the target's existing iframe widget is kept as-is (not deleted, content untouched) and re-attached using the source position and size, so the user's manual configuration on the target survives.

### 3. Respect the source analysis runtime on export

When exporting analyses, the runtime was forced to `node`, ignoring whatever the source analysis used (e.g. `python` or a newer runtime). Imported analyses could then run on the wrong runtime.

The export now keeps the source runtime on create, edit and script upload, defaulting to `node-legacy` only when the source has none. This also bumps `@tago-io/sdk` to 12.2.4, whose `RunTypeOptions` replaced the old `node`/`python` values with `node-legacy`, `python-legacy` and the rt2025 set; `duplicate-analysis` and the backup restore path were updated to match.

## Testing

- `npm test` — 708 passing (added coverage for hidden-tab ordering, custom widget preservation, the skip prompt, and the runtime default).
- `npm run linter` — 0 errors.
- `npm run build` — clean (tsc), man page snapshot updated.

## Risk (CIA)

Low. Confidentiality and availability: stops the source analysis token from leaking into the target, keeps the target's reconfigured custom widget, and runs imported analyses on the correct runtime. No new external exposure or auth change.
