### PR TITLE
feat/device-management-commands

### DIFF
--- a/src/commands/devices/change-bucket-type.ts
+++ b/src/commands/devices/change-bucket-type.ts
@@ -1,4 +1,4 @@
-import { Account } from "@tago-io/sdk";
+import { Resources } from "@tago-io/sdk";
 import kleur from "kleur";
 
 import { getEnvironmentConfig } from "../../lib/config-file.js";
@@ -20,8 +20,8 @@ type environmentConfigResponse = NonNullable<ReturnType<typeof getEnvironmentCon
 const coloredBucketType = (type: string) => (type === "mutable" ? kleur.green(type) : type === "legacy" ? kleur.red(type) : kleur.blue(type));
 
 async function convertDevice(deviceID: string, settings: BucketSettings, config: environmentConfigResponse) {
-  const account = new Account({ token: config.profileToken, region: config?.profileRegion });
-  const deviceInfo = await account.devices.info(deviceID).catch(errorHandler);
+  const resources = new Resources({ token: config.profileToken, region: config?.profileRegion });
+  const deviceInfo = await resources.devices.info(deviceID).catch(errorHandler);
   if (!deviceInfo) {
     return;
   }
@@ -31,12 +31,12 @@ async function convertDevice(deviceID: string, settings: BucketSettings, config:
     return false;
   }
 
-  await account.devices.emptyDeviceData(deviceID);
-  await account.devices.edit(deviceID, { active: false });
+  await resources.devices.emptyDeviceData(deviceID);
+  await resources.devices.edit(deviceID, { active: false });
 
   const reactiveDevice = async () => {
     if (deviceInfo.active !== false) {
-      return account.devices.edit(deviceID, { active: true });
+      return resources.devices.edit(deviceID, { active: true });
     }
   };
 
@@ -84,8 +84,8 @@ async function startBucketChange(config: environmentConfigResponse, deviceID: st
   successMSG(`Device bucket type changed. device=${kleur.blue(deviceID)} type=${coloredBucketType(settings.type)}${extras ? ` ${extras}` : ""}`);
 }
 
-async function chooseBucketsFromList(account: Account) {
-  const bucketList = await account.devices.list({ fields: ["id", "name", "bucket", "type"] }).catch(errorHandler);
+async function chooseBucketsFromList(resources: Resources) {
+  const bucketList = await resources.devices.list({ fields: ["id", "name", "bucket", "type"] }).catch(errorHandler);
   if (!bucketList || bucketList.length === 0) {
     errorHandler("No buckets found");
   }
@@ -105,10 +105,10 @@ async function changeBucketType(id: string, options: { environment: string }) {
   if (!config || !config.profileToken) {
     errorHandler("Environment not found");
   }
-  const account = new Account({ token: config.profileToken, region: config.profileRegion });
-  const bucketList = id ? [id] : await chooseBucketsFromList(account);
+  const resources = new Resources({ token: config.profileToken, region: config.profileRegion });
+  const bucketList = id ? [id] : await chooseBucketsFromList(resources);
   if (id) {
-    const bucketInfo = await account.buckets.info(id).catch((error: unknown) => {
+    const bucketInfo = await resources.buckets.info(id).catch((error: unknown) => {
       const message = error instanceof Error ? error.message : String(error);
       errorHandler(`Device with ID ${id} not found: ${message}`);
     });

--- a/src/commands/devices/change-network.test.ts
+++ b/src/commands/devices/change-network.test.ts
@@ -14,7 +14,7 @@ const promptTextToEnterMock = vi.fn();
 let accountInstance: ReturnType<typeof makeAccount>;
 
 vi.mock("@tago-io/sdk", () => ({
-  Account: function Account() {
+  Resources: function Resources() {
     return accountInstance;
   },
 }));
@@ -135,6 +135,8 @@ describe("changeNetworkOrConnector", () => {
     accountInstance.devices.info.mockResolvedValue({ name: "Dev", network: "old-n", connector: "old-c" });
     accountInstance.devices.tokenList.mockResolvedValue([]);
     accountInstance.devices.edit.mockResolvedValue(undefined);
+    accountInstance.integration.networks.info.mockResolvedValue({ id: "new-net" });
+    accountInstance.integration.connectors.info.mockResolvedValue({ id: "new-conn" });
     promptTextToEnterMock.mockResolvedValueOnce("new-net").mockResolvedValueOnce("new-conn");
 
     const { changeNetworkOrConnector } = await import("./change-network.js");
@@ -159,6 +161,8 @@ describe("changeNetworkOrConnector", () => {
     accountInstance.devices.info.mockResolvedValue({ name: "Dev", network: "old-n", connector: "old-c" });
     accountInstance.devices.tokenList.mockResolvedValue([]);
     accountInstance.devices.edit.mockResolvedValue(undefined);
+    accountInstance.integration.networks.info.mockResolvedValue({ id: "new-n" });
+    accountInstance.integration.connectors.info.mockResolvedValue({ id: "old-c" });
 
     const { changeNetworkOrConnector } = await import("./change-network.js");
     // Only network provided → connector falls back to deviceInfo.connector
@@ -177,6 +181,8 @@ describe("changeNetworkOrConnector", () => {
     accountInstance.devices.tokenDelete.mockResolvedValue(undefined);
     accountInstance.devices.edit.mockResolvedValue(undefined);
     accountInstance.devices.tokenCreate.mockResolvedValue(undefined);
+    accountInstance.integration.networks.info.mockResolvedValue({ id: "new-net" });
+    accountInstance.integration.connectors.info.mockResolvedValue({ id: "new-conn" });
 
     const { changeNetworkOrConnector } = await import("./change-network.js");
     await changeNetworkOrConnector("dev-id", { environment: "prod", networkID: "new-net", connectorID: "new-conn" });
@@ -192,5 +198,103 @@ describe("changeNetworkOrConnector", () => {
       "dev-id",
       expect.objectContaining({ serie_number: undefined, name: "T2", permission: "full" }),
     );
+  });
+
+  test("validates network/connector BEFORE deleting tokens — invalid connector deletes nothing", async () => {
+    getEnvironmentConfigMock.mockReturnValue(makeEnvironmentConfig());
+    accountInstance.devices.info.mockResolvedValue({ name: "Dev", network: "old-n", connector: "old-c" });
+    accountInstance.devices.tokenList.mockResolvedValue([{ token: "t1", name: "T1", serie_number: "SN-1" }]);
+    accountInstance.integration.networks.info.mockResolvedValue({ id: "new-net" });
+    accountInstance.integration.connectors.info.mockRejectedValue(new Error("Connector can't be found"));
+
+    const { changeNetworkOrConnector } = await import("./change-network.js");
+    await expect(
+      changeNetworkOrConnector("dev-id", { environment: "prod", networkID: "new-net", connectorID: "bad-conn" }),
+    ).rejects.toThrow(/connector/i);
+
+    expect(accountInstance.devices.tokenDelete).not.toHaveBeenCalled();
+    expect(accountInstance.devices.edit).not.toHaveBeenCalled();
+  });
+
+  test("recreates tokens before surfacing a failed edit (no process.exit before recreate)", async () => {
+    getEnvironmentConfigMock.mockReturnValue(makeEnvironmentConfig());
+    accountInstance.devices.info.mockResolvedValue({ name: "Dev", network: "old-n", connector: "old-c" });
+    accountInstance.devices.tokenList.mockResolvedValue([{ token: "t1", name: "T1", serie_number: "SN-1" }]);
+    accountInstance.integration.networks.info.mockResolvedValue({ id: "new-net" });
+    accountInstance.integration.connectors.info.mockResolvedValue({ id: "new-conn" });
+    accountInstance.devices.tokenDelete.mockResolvedValue(undefined);
+    accountInstance.devices.edit.mockRejectedValue(new Error("transient API error"));
+    accountInstance.devices.tokenCreate.mockResolvedValue(undefined);
+
+    const { changeNetworkOrConnector } = await import("./change-network.js");
+    await expect(
+      changeNetworkOrConnector("dev-id", { environment: "prod", networkID: "new-net", connectorID: "new-conn" }),
+    ).rejects.toThrow(/Failed to change network\/connector/);
+
+    // The edit failed, but the deleted token MUST be recreated first so the
+    // device is never left tokenless. The edit error is captured (not exited on)
+    // precisely so this recreate runs before the error is surfaced.
+    expect(accountInstance.devices.tokenCreate).toHaveBeenCalledWith(
+      "dev-id",
+      expect.objectContaining({ name: "T1", serie_number: "SN-1", permission: "full" }),
+    );
+  });
+
+  test("warns with the lost tokens when recreate fails", async () => {
+    getEnvironmentConfigMock.mockReturnValue(makeEnvironmentConfig());
+    accountInstance.devices.info.mockResolvedValue({ name: "Dev", network: "old-n", connector: "old-c" });
+    accountInstance.devices.tokenList.mockResolvedValue([{ token: "t1", name: "MyToken", serie_number: "SN-9" }]);
+    accountInstance.integration.networks.info.mockResolvedValue({ id: "new-net" });
+    accountInstance.integration.connectors.info.mockResolvedValue({ id: "new-conn" });
+    accountInstance.devices.tokenDelete.mockResolvedValue(undefined);
+    accountInstance.devices.edit.mockResolvedValue(undefined);
+    accountInstance.devices.tokenCreate.mockRejectedValue(new Error("rate limited"));
+
+    const { changeNetworkOrConnector } = await import("./change-network.js");
+    await expect(
+      changeNetworkOrConnector("dev-id", { environment: "prod", networkID: "new-net", connectorID: "new-conn" }),
+    ).rejects.toThrow(/MyToken/);
+  });
+
+  test("recreate failure on the second token does not report the first (already recreated) as lost", async () => {
+    getEnvironmentConfigMock.mockReturnValue(makeEnvironmentConfig());
+    accountInstance.devices.info.mockResolvedValue({ name: "Dev", network: "old-n", connector: "old-c" });
+    accountInstance.devices.tokenList.mockResolvedValue([
+      { token: "t1", name: "FirstToken", serie_number: "SN-1" },
+      { token: "t2", name: "SecondToken", serie_number: "SN-2" },
+    ]);
+    accountInstance.integration.networks.info.mockResolvedValue({ id: "new-net" });
+    accountInstance.integration.connectors.info.mockResolvedValue({ id: "new-conn" });
+    accountInstance.devices.tokenDelete.mockResolvedValue(undefined);
+    accountInstance.devices.edit.mockResolvedValue(undefined);
+    // First recreate succeeds, second fails.
+    accountInstance.devices.tokenCreate.mockResolvedValueOnce(undefined).mockRejectedValueOnce(new Error("rate limited"));
+
+    const { changeNetworkOrConnector } = await import("./change-network.js");
+    const promise = changeNetworkOrConnector("dev-id", { environment: "prod", networkID: "new-net", connectorID: "new-conn" });
+
+    // Only the token that actually failed must be reported as lost.
+    await expect(promise).rejects.toThrow(/SecondToken/);
+    await expect(promise).rejects.not.toThrow(/FirstToken/);
+    // Both recreate attempts ran (the loop is not short-circuited on the first failure).
+    expect(accountInstance.devices.tokenCreate).toHaveBeenCalledTimes(2);
+  });
+
+  test("propagates the original edit error when recreate succeeds (no masking)", async () => {
+    getEnvironmentConfigMock.mockReturnValue(makeEnvironmentConfig());
+    accountInstance.devices.info.mockResolvedValue({ name: "Dev", network: "old-n", connector: "old-c" });
+    accountInstance.devices.tokenList.mockResolvedValue([{ token: "t1", name: "T1", serie_number: "SN-1" }]);
+    accountInstance.integration.networks.info.mockResolvedValue({ id: "new-net" });
+    accountInstance.integration.connectors.info.mockResolvedValue({ id: "new-conn" });
+    accountInstance.devices.tokenDelete.mockResolvedValue(undefined);
+    accountInstance.devices.edit.mockRejectedValue(new Error("EDIT_BOOM"));
+    accountInstance.devices.tokenCreate.mockResolvedValue(undefined);
+
+    const { changeNetworkOrConnector } = await import("./change-network.js");
+    // The edit error must still surface after the tokens are recreated.
+    await expect(
+      changeNetworkOrConnector("dev-id", { environment: "prod", networkID: "new-net", connectorID: "new-conn" }),
+    ).rejects.toThrow(/EDIT_BOOM/);
+    expect(accountInstance.devices.tokenCreate).toHaveBeenCalledTimes(1);
   });
 });

--- a/src/commands/devices/change-network.ts
+++ b/src/commands/devices/change-network.ts
@@ -1,4 +1,4 @@
-import { Account } from "@tago-io/sdk";
+import { Resources } from "@tago-io/sdk";
 import kleur from "kleur";
 
 import { getEnvironmentConfig } from "../../lib/config-file.js";
@@ -13,6 +13,12 @@ interface BucketSettings {
   connector: string;
 }
 
+interface DeviceToken {
+  token: string;
+  name: string;
+  serie_number?: string;
+}
+
 type environmentConfigResponse = NonNullable<ReturnType<typeof getEnvironmentConfig>>;
 
 function _formatUpdateMessage(deviceID: string, serialNumbers: (string | undefined)[], network: string, connector: string) {
@@ -21,27 +27,85 @@ function _formatUpdateMessage(deviceID: string, serialNumbers: (string | undefin
   return `Device network and connector updated. device=${kleur.blue(deviceID)}${serialPart} network=${kleur.cyan(network)} connector=${kleur.cyan(connector)}`;
 }
 
-async function updateDevice(config: environmentConfigResponse, deviceID: string, settings: BucketSettings) {
-  const account = new Account({ token: config.profileToken, region: config.profileRegion });
+/**
+ * Validates that the target network and connector exist before any destructive
+ * step. The TagoIO API rejects a network/connector change while the device
+ * still has tokens, so the change requires deleting every token first. By
+ * validating up front, an invalid id fails cleanly without ever deleting a
+ * token — covering the common failure (bad connector) instead of relying on a
+ * rollback after the damage is done.
+ */
+async function validateNetworkAndConnector(resources: Resources, network: string, connector: string) {
+  await resources.integration.networks.info(network).catch(() => {
+    errorHandler(`Invalid network: ${network} could not be found.`);
+  });
+  await resources.integration.connectors.info(connector).catch(() => {
+    errorHandler(`Invalid connector: ${connector} could not be found.`);
+  });
+}
 
-  const tokens = await account.devices.tokenList(deviceID, { fields: ["name", "token", "permission", "serie_number"] });
-  const tokenList = tokens.map((token) => token.token);
+/** Describes a token for the manual-recreate hint: name plus serial when present. */
+function describeToken(token: DeviceToken) {
+  return `${token.name}${token.serie_number ? ` (serial ${token.serie_number})` : ""}`;
+}
 
-  if (tokenList) {
-    for (const token of tokenList) {
-      await account.devices.tokenDelete(token);
-    }
-  }
-
-  await account.devices.edit(deviceID, { network: settings.network, connector: settings.connector, active: true });
-
-  const serialNumbers: (string | undefined)[] = [];
+/**
+ * Recreates the previously deleted tokens, preserving each token's name and
+ * serial number. Runs in a `finally` so the device is never left tokenless,
+ * even when the edit fails. Every token is attempted (one failure does not skip
+ * the rest); if any fail to recreate, the error lists ONLY those so the user
+ * doesn't recreate tokens that already came back.
+ */
+async function recreateTokens(resources: Resources, deviceID: string, tokens: DeviceToken[]) {
+  const failed: DeviceToken[] = [];
   for (const token of tokens) {
-    const serieNumber = token.serie_number as string | undefined;
-    serialNumbers.push(serieNumber);
-    await account.devices.tokenCreate(deviceID, { serie_number: serieNumber, name: token.name, permission: "full" });
+    await resources.devices
+      .tokenCreate(deviceID, { serie_number: token.serie_number, name: token.name, permission: "full" })
+      .catch(() => failed.push(token));
   }
 
+  if (failed.length > 0) {
+    const lost = failed.map(describeToken).join(", ");
+    errorHandler(
+      `Failed to recreate device tokens after the network change. Recreate them manually: ${lost}. ` +
+        `Use: tagoio device-token ${deviceID} --create "<name>"`,
+    );
+  }
+}
+
+async function updateDevice(config: environmentConfigResponse, deviceID: string, settings: BucketSettings) {
+  const resources = new Resources({ token: config.profileToken, region: config.profileRegion });
+
+  // Validate the target network/connector BEFORE touching tokens. A bad id
+  // fails here, leaving the device's tokens untouched.
+  await validateNetworkAndConnector(resources, settings.network, settings.connector);
+
+  const tokens = (await resources.devices.tokenList(deviceID, {
+    fields: ["name", "token", "permission", "serie_number"],
+  })) as DeviceToken[];
+
+  for (const token of tokens) {
+    await resources.devices.tokenDelete(token.token);
+  }
+
+  // Call edit directly (not via applyDeviceEdit) and capture the error instead
+  // of letting it exit the process: the tokens were just deleted, so they MUST
+  // be recreated before we surface any edit failure. A `finally` would not be
+  // enough here — applyDeviceEdit/errorHandler call process.exit(1), which
+  // skips finally blocks entirely and would leave the device tokenless.
+  const editError = await resources.devices
+    .edit(deviceID, { network: settings.network, connector: settings.connector, active: true })
+    .then(() => undefined)
+    .catch((error: unknown) => (error instanceof Error ? error.message : String(error)));
+
+  // Recreate tokens first, regardless of whether the edit succeeded.
+  await recreateTokens(resources, deviceID, tokens);
+
+  if (editError) {
+    errorHandler(`Failed to change network/connector for device ${deviceID}: ${editError}`);
+  }
+
+  const serialNumbers = tokens.map((token) => token.serie_number);
   successMSG(_formatUpdateMessage(deviceID, serialNumbers, settings.network, settings.connector));
 }
 
@@ -55,13 +119,13 @@ async function changeNetworkOrConnector(id: string, options: { environment: stri
 
   let { networkID, connectorID } = options;
 
-  const account = new Account({ token: config.profileToken, region: config.profileRegion });
-  const deviceID = id || (await pickDeviceIDFromTagoIO(account));
+  const resources = new Resources({ token: config.profileToken, region: config.profileRegion });
+  const deviceID = id || (await pickDeviceIDFromTagoIO(resources));
   if (!deviceID) {
     return;
   }
 
-  const deviceInfo = await account.devices.info(deviceID).catch(errorHandler);
+  const deviceInfo = await resources.devices.info(deviceID).catch(errorHandler);
   if (!deviceInfo) {
     return;
   }

--- a/src/commands/devices/copy-data.test.ts
+++ b/src/commands/devices/copy-data.test.ts
@@ -8,26 +8,26 @@ const getEnvironmentConfigMock = vi.fn();
 const errorHandlerMock = vi.fn((str: unknown) => {
   throw new Error(String(str));
 });
-const getDeviceMock = vi.fn();
 const pickDeviceIDFromTagoIOMock = vi.fn();
 const confirmPromptMock = vi.fn();
 
-let accountInstance: ReturnType<typeof makeAccount>;
+let resourcesInstance: ReturnType<typeof makeAccount>;
 
 const deviceInfoMock = vi.fn();
+
 const sendDataMock = vi.fn();
-const getDataStreamingMock = vi.fn();
 
 vi.mock("@tago-io/sdk", () => ({
-  Account: function Account() {
-    return accountInstance;
+  Resources: function Resources() {
+    return resourcesInstance;
   },
   Device: function Device() {
-    return { info: deviceInfoMock, sendData: sendDataMock, getDataStreaming: getDataStreamingMock };
+    return { info: deviceInfoMock };
   },
-  Utils: {
-    getDevice: (...args: unknown[]) => getDeviceMock(...args),
-  },
+}));
+
+vi.mock("./device-sender.js", () => ({
+  getDeviceForSending: vi.fn(async () => ({ sendData: sendDataMock })),
 }));
 
 vi.mock("../../lib/config-file.js", () => ({
@@ -63,17 +63,18 @@ vi.mock("../../prompt/confirm.js", () => ({
   confirmPrompt: (...args: unknown[]) => confirmPromptMock(...args),
 }));
 
+const ID_FROM = "a".repeat(24);
+const ID_TO = "b".repeat(24);
+
 describe("copyDeviceData", () => {
   beforeEach(() => {
-    accountInstance = makeAccount();
+    resourcesInstance = makeAccount();
     getEnvironmentConfigMock.mockReset();
     errorHandlerMock.mockClear();
-    getDeviceMock.mockReset();
     pickDeviceIDFromTagoIOMock.mockReset();
     confirmPromptMock.mockReset();
     deviceInfoMock.mockReset();
     sendDataMock.mockReset();
-    getDataStreamingMock.mockReset();
     resetInjectedPrompts();
   });
 
@@ -81,54 +82,51 @@ describe("copyDeviceData", () => {
     getEnvironmentConfigMock.mockReturnValue(makeEnvironmentConfig({ profileToken: "" }));
 
     const { copyDeviceData } = await import("./copy-data.js");
-    await expect(
-      copyDeviceData({ from: "a".repeat(24), to: "b".repeat(24), environment: "prod", amount: 10 }),
-    ).rejects.toThrow(/Environment not found/);
+    await expect(copyDeviceData({ from: ID_FROM, to: ID_TO, environment: "prod", amount: 10 })).rejects.toThrow(
+      /Environment not found/,
+    );
   });
 
-  test("calls errorHandler when the destination device cannot be resolved", async () => {
+  test("surfaces the error when a device info cannot be resolved", async () => {
     getEnvironmentConfigMock.mockReturnValue(makeEnvironmentConfig());
-    getDeviceMock.mockResolvedValue(null);
+    resourcesInstance.devices.info.mockRejectedValue(new Error("404"));
 
     const { copyDeviceData } = await import("./copy-data.js");
-    await expect(
-      copyDeviceData({ from: "a".repeat(24), to: "b".repeat(24), environment: "prod", amount: 10 }),
-    ).rejects.toThrow(/Device not found/);
+    await expect(copyDeviceData({ from: ID_FROM, to: ID_TO, environment: "prod", amount: 10 })).rejects.toThrow(/404/);
   });
 
   test("prompts for device IDs when from/to are not provided", async () => {
     getEnvironmentConfigMock.mockReturnValue(makeEnvironmentConfig());
-    pickDeviceIDFromTagoIOMock.mockResolvedValueOnce("from-id-aaaaaaaaaaaaaaaaaaaa"); // 24 chars
-    pickDeviceIDFromTagoIOMock.mockResolvedValueOnce("to-id-aaaaaaaaaaaaaaaaaaaa"); // 26 chars
-    getDeviceMock.mockResolvedValue(null);
+    pickDeviceIDFromTagoIOMock.mockResolvedValueOnce(ID_FROM).mockResolvedValueOnce(ID_TO);
+    resourcesInstance.devices.info.mockResolvedValue({ id: ID_FROM, name: "Dev" });
+    confirmPromptMock.mockResolvedValue(false);
 
     const { copyDeviceData } = await import("./copy-data.js");
-    await expect(
-      copyDeviceData({ from: "", to: "", environment: "prod", amount: 10 }),
-    ).rejects.toThrow(/Device not found/);
+    await copyDeviceData({ from: "", to: "", environment: "prod", amount: 10 });
+
     expect(pickDeviceIDFromTagoIOMock).toHaveBeenCalledTimes(2);
   });
 
   test("returns early when confirmPrompt is false", async () => {
     getEnvironmentConfigMock.mockReturnValue(makeEnvironmentConfig());
-    const fromDevice = { info: vi.fn().mockResolvedValue({ name: "From" }) };
-    const toDevice = { info: vi.fn().mockResolvedValue({ name: "To" }) };
-    getDeviceMock.mockResolvedValueOnce(fromDevice).mockResolvedValueOnce(toDevice);
+    resourcesInstance.devices.info
+      .mockResolvedValueOnce({ id: ID_FROM, name: "From" })
+      .mockResolvedValueOnce({ id: ID_TO, name: "To" });
     confirmPromptMock.mockResolvedValue(false);
 
     const { copyDeviceData } = await import("./copy-data.js");
-    const result = await copyDeviceData({
-      from: "a".repeat(24),
-      to: "b".repeat(24),
-      environment: "prod",
-      amount: 10,
-    });
+    const result = await copyDeviceData({ from: ID_FROM, to: ID_TO, environment: "prod", amount: 10 });
+
     expect(result).toBeUndefined();
     expect(confirmPromptMock).toHaveBeenCalled();
+    expect(sendDataMock).not.toHaveBeenCalled();
   });
 
-  test("streams and sends data when user confirms", async () => {
+  test("streams from source and sends to destination when user confirms", async () => {
     getEnvironmentConfigMock.mockReturnValue(makeEnvironmentConfig());
+    resourcesInstance.devices.info
+      .mockResolvedValueOnce({ id: ID_FROM, name: "From" })
+      .mockResolvedValueOnce({ id: ID_TO, name: "To" });
     const streamChunks = [
       [
         { variable: "x", value: 1 },
@@ -141,24 +139,15 @@ describe("copyDeviceData", () => {
         yield chunk;
       }
     }
-    const fromDevice = {
-      info: vi.fn().mockResolvedValue({ name: "From" }),
-      getDataStreaming: vi.fn(() => stream()),
-    };
-    const toDevice = {
-      info: vi.fn().mockResolvedValue({ name: "To" }),
-      sendData: vi.fn().mockResolvedValue(undefined),
-    };
-    getDeviceMock.mockResolvedValueOnce(fromDevice).mockResolvedValueOnce(toDevice);
+    resourcesInstance.devices.getDeviceDataStreaming.mockReturnValue(stream());
+    sendDataMock.mockResolvedValue(undefined);
     confirmPromptMock.mockResolvedValue(true);
 
     const { copyDeviceData } = await import("./copy-data.js");
-    await copyDeviceData({
-      from: "a".repeat(24),
-      to: "b".repeat(24),
-      environment: "prod",
-      amount: 1,
-    });
-    expect(toDevice.sendData).toHaveBeenCalled();
+    await copyDeviceData({ from: ID_FROM, to: ID_TO, environment: "prod", amount: 1 });
+
+    expect(resourcesInstance.devices.getDeviceDataStreaming).toHaveBeenCalledWith(ID_FROM, {}, expect.any(Object));
+    // The "payload" variable is filtered out before sending; data is written via the destination device token.
+    expect(sendDataMock).toHaveBeenCalledWith([{ variable: "x", value: 1 }]);
   });
 });

--- a/src/commands/devices/copy-data.ts
+++ b/src/commands/devices/copy-data.ts
@@ -1,4 +1,4 @@
-import { Account, Device, Utils } from "@tago-io/sdk";
+import { Device, Resources } from "@tago-io/sdk";
 
 import { getEnvironmentConfig } from "../../lib/config-file.js";
 import { errorHandler, highlightMSG, infoMSG, successMSG } from "../../lib/messages.js";
@@ -6,6 +6,7 @@ import { resolveScope } from "../../lib/resolve-scope.js";
 import { printScopeBanner } from "../../lib/scope-notice.js";
 import { confirmPrompt } from "../../prompt/confirm.js";
 import { pickDeviceIDFromTagoIO } from "../../prompt/pick-device-id-from-tagoio.js";
+import { getDeviceForSending } from "./device-sender.js";
 
 interface IOptions {
   to: string;
@@ -14,15 +15,27 @@ interface IOptions {
   amount: number;
 }
 
-async function startCopy(deviceFrom: Device, deviceTo: Device, options: IOptions) {
+type DeviceRegion = ConstructorParameters<typeof Device>[0]["region"];
+
+/** Resolves a device id from an id (24-char) or a device token. */
+async function resolveDeviceID(idOrToken: string, region: DeviceRegion) {
+  if (idOrToken.length === 24) {
+    return idOrToken;
+  }
+  const info = await new Device({ token: idOrToken, region }).info().catch(errorHandler);
+  return info?.id;
+}
+
+async function startCopy(resources: Resources, deviceTo: Device, fromID: string, options: IOptions) {
   const { amount } = options;
 
-  const dataStream = deviceFrom.getDataStreaming({}, { poolingRecordQty: 2000, poolingTime: 400, neverStop: false });
+  const dataStream = resources.devices.getDeviceDataStreaming(fromID, {}, { poolingRecordQty: 2000, poolingTime: 400, neverStop: false });
 
   let total = 0;
   for await (let data of dataStream) {
     data = data.filter((x) => x.variable !== "payload");
     total += data.length;
+    // Write through the destination device token: profile tokens cannot send data.
     await deviceTo.sendData(data);
     if (total >= amount) {
       break;
@@ -40,42 +53,23 @@ async function copyDeviceData(options: IOptions) {
     errorHandler("Environment not found");
   }
 
+  const resources = new Resources({ token: config.profileToken, region: config.profileRegion });
+
   if (!options.from || !options.to) {
-    const account = new Account({ token: config.profileToken, region: config.profileRegion });
-    options.from = await pickDeviceIDFromTagoIO(account, "Choose a device to copy the data from:");
-    options.to = await pickDeviceIDFromTagoIO(account, "Choose a device to copy the data to: ");
+    options.from = await pickDeviceIDFromTagoIO(resources, "Choose a device to copy the data from:");
+    options.to = await pickDeviceIDFromTagoIO(resources, "Choose a device to copy the data to: ");
   }
 
-  let deviceFrom: Device | undefined;
-  let deviceTo: Device | undefined;
-  if (options.from?.length === 24 || options.to?.length === 24) {
-    const account = new Account({ token: config.profileToken, region: config.profileRegion });
-
-    if (options.from.length === 24) {
-      deviceFrom = await Utils.getDevice(account, options.from);
-    }
-
-    if (options.to.length === 24) {
-      deviceTo = await Utils.getDevice(account, options.to);
-    }
+  const fromID = await resolveDeviceID(options.from, config.profileRegion);
+  const toID = await resolveDeviceID(options.to, config.profileRegion);
+  if (!fromID || !toID) {
+    return errorHandler("Device not found");
   }
 
-  if (!deviceTo || !deviceFrom) {
-    errorHandler("Device not found");
-  }
-
-  if (!deviceFrom) {
-    deviceFrom = new Device({ token: options.from });
-  }
-
-  if (!deviceTo) {
-    deviceTo = new Device({ token: options.to });
-  }
-
-  const deviceToInfo = await deviceTo.info().catch(errorHandler);
-  const deviceFromInfo = await deviceFrom.info().catch(errorHandler);
+  const deviceFromInfo = await resources.devices.info(fromID).catch(errorHandler);
+  const deviceToInfo = await resources.devices.info(toID).catch(errorHandler);
   if (!deviceToInfo || !deviceFromInfo) {
-    errorHandler("Device not found");
+    return errorHandler("Device not found");
   }
 
   const yesNo = await confirmPrompt(`Copy data from ${highlightMSG(deviceFromInfo.name)} to ${highlightMSG(deviceToInfo.name)}?`);
@@ -83,8 +77,10 @@ async function copyDeviceData(options: IOptions) {
     return;
   }
 
+  const deviceTo = await getDeviceForSending(resources, toID, config.profileRegion);
+
   infoMSG(`> Copying data from ${highlightMSG(deviceFromInfo.name)} to ${highlightMSG(deviceToInfo.name)}...`);
-  await startCopy(deviceFrom, deviceTo, options);
+  await startCopy(resources, deviceTo, fromID, options);
 }
 
 export { copyDeviceData };

--- a/src/commands/devices/data-get.test.ts
+++ b/src/commands/devices/data-get.test.ts
@@ -1,3 +1,4 @@
+import prompts from "prompts";
 import { beforeEach, describe, expect, test, vi } from "vitest";
 
 import { makeEnvironmentConfig } from "../../test-utils/mock-config.js";
@@ -8,23 +9,29 @@ const errorHandlerMock = vi.fn((str: unknown) => {
 });
 
 const accountDevicesInfoMock = vi.fn();
-const utilsGetDeviceMock = vi.fn();
 const deviceInfoMock = vi.fn();
 const deviceGetDataMock = vi.fn();
+const deviceDeleteDataMock = vi.fn();
+const deviceEmptyDataMock = vi.fn();
 const pickDeviceIDFromTagoIOMock = vi.fn();
 const postDeviceDataMock = vi.fn();
 
 vi.mock("@tago-io/sdk", () => ({
-  Account: function Account() {
-    return { devices: { info: (...args: unknown[]) => accountDevicesInfoMock(...args) } };
+  Resources: function Resources() {
+    return {
+      devices: {
+        info: (...args: unknown[]) => accountDevicesInfoMock(...args),
+        getDeviceData: (...args: unknown[]) => deviceGetDataMock(...args),
+        deleteDeviceData: (...args: unknown[]) => deviceDeleteDataMock(...args),
+        emptyDeviceData: (...args: unknown[]) => deviceEmptyDataMock(...args),
+      },
+    };
   },
   Device: function Device() {
     return {
       info: (...args: unknown[]) => deviceInfoMock(...args),
-      getData: (...args: unknown[]) => deviceGetDataMock(...args),
     };
   },
-  Utils: { getDevice: (...args: unknown[]) => utilsGetDeviceMock(...args) },
 }));
 
 vi.mock("../../lib/config-file.js", () => ({
@@ -112,15 +119,13 @@ describe("getDeviceData", () => {
   test("fetches device by id when length is not 36", async () => {
     getEnvironmentConfigMock.mockReturnValue(makeEnvironmentConfig());
     accountDevicesInfoMock.mockResolvedValue({ id: "dev", name: "Device", type: "mutable" });
-    utilsGetDeviceMock.mockResolvedValue({
-      getData: deviceGetDataMock,
-    });
     deviceGetDataMock.mockResolvedValue([]);
     vi.spyOn(console, "table").mockImplementation(() => undefined);
 
     const { getDeviceData } = await import("./data-get.js");
     await getDeviceData("short-id", { post: "", json: true } as never);
     expect(accountDevicesInfoMock).toHaveBeenCalledWith("short-id");
+    expect(deviceGetDataMock).toHaveBeenCalledWith("dev", expect.any(Object));
   });
 
   test("emits pretty-printed JSON to stdout when --stringify is set", async () => {
@@ -142,12 +147,76 @@ describe("getDeviceData", () => {
     getEnvironmentConfigMock.mockReturnValue(makeEnvironmentConfig());
     pickDeviceIDFromTagoIOMock.mockResolvedValue("picked-id");
     accountDevicesInfoMock.mockResolvedValue({ id: "dev", name: "X", type: "mutable" });
-    utilsGetDeviceMock.mockResolvedValue({ getData: deviceGetDataMock });
     deviceGetDataMock.mockResolvedValue([]);
     vi.spyOn(console, "table").mockImplementation(() => undefined);
 
     const { getDeviceData } = await import("./data-get.js");
     await getDeviceData("", { post: "" } as never);
     expect(pickDeviceIDFromTagoIOMock).toHaveBeenCalled();
+  });
+
+  test("--delete deletes data matching the query filter", async () => {
+    getEnvironmentConfigMock.mockReturnValue(makeEnvironmentConfig());
+    deviceInfoMock.mockResolvedValue({ id: "dev", name: "Device", type: "mutable" });
+    deviceDeleteDataMock.mockResolvedValue("3 Data Removed");
+
+    const { getDeviceData } = await import("./data-get.js");
+    await getDeviceData("a".repeat(36), { delete: true, var: ["temperature"] } as never);
+
+    expect(deviceDeleteDataMock).toHaveBeenCalledWith("dev", expect.objectContaining({ variables: ["temperature"] }));
+    expect(deviceGetDataMock).not.toHaveBeenCalled();
+  });
+
+  test("--empty deletes all data after confirmation via emptyDeviceData", async () => {
+    getEnvironmentConfigMock.mockReturnValue(makeEnvironmentConfig());
+    deviceInfoMock.mockResolvedValue({ id: "dev", name: "Device", type: "mutable" });
+    deviceEmptyDataMock.mockResolvedValue("All Data Removed");
+    prompts.inject([true]);
+
+    const { getDeviceData } = await import("./data-get.js");
+    await getDeviceData("a".repeat(36), { empty: true } as never);
+
+    expect(deviceEmptyDataMock).toHaveBeenCalledWith("dev");
+  });
+
+  test("--empty without confirmation makes no delete call", async () => {
+    getEnvironmentConfigMock.mockReturnValue(makeEnvironmentConfig());
+    deviceInfoMock.mockResolvedValue({ id: "dev", name: "Device", type: "mutable" });
+    prompts.inject([false]);
+
+    const { getDeviceData } = await import("./data-get.js");
+    await getDeviceData("a".repeat(36), { empty: true } as never);
+
+    expect(deviceEmptyDataMock).not.toHaveBeenCalled();
+  });
+
+  test("--empty -y skips confirmation", async () => {
+    getEnvironmentConfigMock.mockReturnValue(makeEnvironmentConfig());
+    deviceInfoMock.mockResolvedValue({ id: "dev", name: "Device", type: "mutable" });
+    deviceEmptyDataMock.mockResolvedValue("All Data Removed");
+
+    const { getDeviceData } = await import("./data-get.js");
+    await getDeviceData("a".repeat(36), { empty: true, yes: true } as never);
+
+    expect(deviceEmptyDataMock).toHaveBeenCalledWith("dev");
+  });
+
+  test("--delete together with --post is rejected (mutual exclusivity)", async () => {
+    getEnvironmentConfigMock.mockReturnValue(makeEnvironmentConfig());
+
+    const { getDeviceData } = await import("./data-get.js");
+    await expect(getDeviceData("a".repeat(36), { delete: true, post: "{...}" } as never)).rejects.toThrow(
+      /mutually exclusive/,
+    );
+    expect(postDeviceDataMock).not.toHaveBeenCalled();
+  });
+
+  test("--delete and --empty together is rejected", async () => {
+    getEnvironmentConfigMock.mockReturnValue(makeEnvironmentConfig());
+
+    const { getDeviceData } = await import("./data-get.js");
+    await expect(getDeviceData("a".repeat(36), { delete: true, empty: true } as never)).rejects.toThrow(
+      /mutually exclusive/,
+    );
   });
 });

--- a/src/commands/devices/data-get.ts
+++ b/src/commands/devices/data-get.ts
@@ -1,5 +1,6 @@
-import { Account, Data, DataQuery, Device, Utils } from "@tago-io/sdk";
+import { Data, DataQuery, Device, Resources } from "@tago-io/sdk";
 import kleur from "kleur";
+import prompts from "prompts";
 
 // import { DataQuery } from "@tago-io/sdk";
 import { getEnvironmentConfig } from "../../lib/config-file.js";
@@ -8,29 +9,27 @@ import { pickDeviceIDFromTagoIO } from "../../prompt/pick-device-id-from-tagoio.
 import { postDeviceData } from "./data-post.js";
 
 /**
- * Get device information and instance based on the provided ID or token.
- * @param {string} idOrToken - The ID or token of the device to retrieve.
- * @param {Account} account - The TagoIO account instance.
- * @returns {Promise<{device: Device, info: DeviceInfo}>} - A promise that resolves to an object containing the device instance and information.
+ * Resolves a device's id and info from an ID or a device token. A 36-char input
+ * is treated as a device token (resolved via a Device instance); anything else
+ * is treated as a device id and looked up through the profile. Returns the
+ * resolved id so callers can drive `resources.devices.*` operations by id.
  */
-async function getDevice(idOrToken: string, account: Account) {
-  let device;
+async function getDevice(idOrToken: string, resources: Resources) {
   let info;
 
   if (idOrToken.length === 36) {
-    device = new Device({ token: idOrToken });
+    const device = new Device({ token: idOrToken });
     info = await device.info().catch(errorHandler);
   } else {
-    info = await account.devices.info(idOrToken).catch(errorHandler);
-    device = await Utils.getDevice(account, info?.id as string).catch(errorHandler);
+    info = await resources.devices.info(idOrToken).catch(errorHandler);
   }
 
-  if (!device || !info) {
+  if (!info) {
     return;
   }
 
   return {
-    device,
+    id: info.id,
     info,
   };
 }
@@ -73,10 +72,50 @@ interface IOptions {
   qty: string;
   post: string;
   json?: boolean;
+  delete?: boolean;
+  empty?: boolean;
+  yes?: boolean;
   query: "count" | "sum" | "avg" | "min" | "max" | "first" | "last";
 }
 
+/**
+ * Deletes data from a device (mutable only). `--empty` clears all data and
+ * confirms first unless `-y`/`--silent`; `--delete` removes data matching the
+ * query filters. Operates by device id through `resources.devices`.
+ */
+async function deleteDeviceData(resources: Resources, deviceID: string, deviceInfo: { name: string }, options: IOptions) {
+  if (options.empty && !options.yes) {
+    const { confirm } = await prompts({
+      type: "confirm",
+      name: "confirm",
+      message: `Permanently delete ALL data from ${deviceInfo.name}? This cannot be undone.`,
+      initial: false,
+    });
+    if (confirm !== true) {
+      successMSG("Cancelled. No data deleted.");
+      return;
+    }
+  }
+
+  const result = options.empty
+    ? await resources.devices.emptyDeviceData(deviceID).catch((error) => errorHandler(error))
+    : await resources.devices.deleteDeviceData(deviceID, _createDataFilter(options)).catch((error) => errorHandler(error));
+
+  if (options.json) {
+    process.stdout.write(`${JSON.stringify({ id: deviceID, deleted: true, result })}\n`);
+    return;
+  }
+  successMSG(`Data deleted from ${kleur.cyan(deviceInfo.name)}: ${kleur.dim(String(result))}`);
+}
+
 async function getDeviceData(idOrToken: string, options: IOptions) {
+  // --delete/--empty/--post each take a different action on the same data; only
+  // one may run per invocation.
+  const ops = [Boolean(options.post), Boolean(options.delete), Boolean(options.empty)].filter(Boolean);
+  if (ops.length > 1) {
+    errorHandler("--post, --delete and --empty are mutually exclusive — pass only one.");
+  }
+
   if (options.post) {
     await postDeviceData(idOrToken, options);
     return;
@@ -86,22 +125,27 @@ async function getDeviceData(idOrToken: string, options: IOptions) {
   if (!config || !config.profileToken) {
     errorHandler("Environment not found");
   }
-  const account = new Account({ token: config.profileToken, region: config.profileRegion });
+  const resources = new Resources({ token: config.profileToken, region: config.profileRegion });
   if (!idOrToken) {
-    idOrToken = await pickDeviceIDFromTagoIO(account);
+    idOrToken = await pickDeviceIDFromTagoIO(resources);
   }
-  const deviceResult = await getDevice(idOrToken, account).catch(errorHandler);
+  const deviceResult = await getDevice(idOrToken, resources).catch(errorHandler);
   if (!deviceResult) {
     return;
   }
 
-  const { device, info: deviceInfo } = deviceResult;
+  const { id: deviceID, info: deviceInfo } = deviceResult;
+
+  if (options.delete || options.empty) {
+    await deleteDeviceData(resources, deviceID, deviceInfo, options);
+    return;
+  }
 
   const filter = _createDataFilter(options);
 
   infoMSG(`Query Filter: ${kleur.cyan(JSON.stringify(filter))}`);
-  const dataList = await device
-    .getData(filter as any)
+  const dataList = await resources.devices
+    .getDeviceData(deviceID, filter)
     .then((r) => {
       return r.map((x) => {
         // @ts-expect-error ignore error

--- a/src/commands/devices/data-post.test.ts
+++ b/src/commands/devices/data-post.test.ts
@@ -13,18 +13,18 @@ const pickDeviceIDFromTagoIOMock = vi.fn();
 
 let accountInstance: ReturnType<typeof makeAccount>;
 const deviceInstance = { sendData: vi.fn(), info: vi.fn() };
-const getDeviceMock = vi.fn();
 
 vi.mock("@tago-io/sdk", () => ({
-  Account: function Account() {
+  Resources: function Resources() {
     return accountInstance;
   },
   Device: function Device() {
     return deviceInstance;
   },
-  Utils: {
-    getDevice: (...args: unknown[]) => getDeviceMock(...args),
-  },
+}));
+
+vi.mock("./device-sender.js", () => ({
+  getDeviceForSending: vi.fn(async () => deviceInstance),
 }));
 
 vi.mock("../../lib/config-file.js", () => ({
@@ -63,7 +63,6 @@ describe("postDeviceData", () => {
     successMSGMock.mockClear();
     deviceInstance.sendData.mockReset();
     deviceInstance.info.mockReset();
-    getDeviceMock.mockReset();
     pickDeviceIDFromTagoIOMock.mockReset();
     resetInjectedPrompts();
   });
@@ -75,16 +74,15 @@ describe("postDeviceData", () => {
     await expect(postDeviceData("dev-id", { environment: "prod", post: "[]" })).rejects.toThrow(/Environment not found/);
   });
 
-  test("sends the parsed JSON payload via the resolved device", async () => {
+  test("sends the parsed JSON payload via a device token instance", async () => {
     getEnvironmentConfigMock.mockReturnValue(makeEnvironmentConfig());
     accountInstance.devices.info.mockResolvedValue({ id: "dev-id" });
-    const device = { sendData: vi.fn().mockResolvedValue({ ok: 1 }) };
-    getDeviceMock.mockResolvedValue(device);
+    deviceInstance.sendData.mockResolvedValue({ ok: 1 });
 
     const { postDeviceData } = await import("./data-post.js");
     await postDeviceData("dev-id", { environment: "prod", post: '[{"variable":"temp","value":20}]' });
 
-    expect(device.sendData).toHaveBeenCalledWith([{ variable: "temp", value: 20 }]);
+    expect(deviceInstance.sendData).toHaveBeenCalledWith([{ variable: "temp", value: 20 }]);
     expect(successMSGMock).toHaveBeenCalled();
   });
 
@@ -92,8 +90,7 @@ describe("postDeviceData", () => {
     getEnvironmentConfigMock.mockReturnValue(makeEnvironmentConfig());
     pickDeviceIDFromTagoIOMock.mockResolvedValue("picked-id");
     accountInstance.devices.info.mockResolvedValue({ id: "picked-id" });
-    const device = { sendData: vi.fn().mockResolvedValue({ ok: 1 }) };
-    getDeviceMock.mockResolvedValue(device);
+    deviceInstance.sendData.mockResolvedValue({ ok: 1 });
 
     const { postDeviceData } = await import("./data-post.js");
     await postDeviceData("", { environment: "prod", post: "[]" });
@@ -104,13 +101,12 @@ describe("postDeviceData", () => {
     getEnvironmentConfigMock.mockReturnValue(makeEnvironmentConfig());
     accountInstance.devices.info.mockRejectedValue(new Error("404"));
     deviceInstance.info.mockResolvedValue({ id: "dev-from-token" });
-    const device = { sendData: vi.fn().mockResolvedValue({ ok: 1 }) };
-    getDeviceMock.mockResolvedValue(device);
+    deviceInstance.sendData.mockResolvedValue({ ok: 1 });
 
     const { postDeviceData } = await import("./data-post.js");
     await postDeviceData("some-token", { environment: "prod", post: "[]" });
     expect(deviceInstance.info).toHaveBeenCalled();
-    expect(device.sendData).toHaveBeenCalled();
+    expect(deviceInstance.sendData).toHaveBeenCalledWith([]);
   });
 
   test("returns silently when both account and device lookup fail", async () => {

--- a/src/commands/devices/data-post.ts
+++ b/src/commands/devices/data-post.ts
@@ -1,10 +1,11 @@
-import { Account, Device, Utils } from "@tago-io/sdk";
+import { Device, Resources } from "@tago-io/sdk";
 
 import { getEnvironmentConfig } from "../../lib/config-file.js";
 import { errorHandler, successMSG } from "../../lib/messages.js";
 import { resolveScope } from "../../lib/resolve-scope.js";
 import { printScopeBanner } from "../../lib/scope-notice.js";
 import { pickDeviceIDFromTagoIO } from "../../prompt/pick-device-id-from-tagoio.js";
+import { getDeviceForSending } from "./device-sender.js";
 
 interface IOptions {
   environment?: string;
@@ -19,11 +20,11 @@ async function postDeviceData(idOrToken: string, options: IOptions) {
     errorHandler("Environment not found");
   }
 
-  const account = new Account({ token: config.profileToken, region: config.profileRegion });
+  const resources = new Resources({ token: config.profileToken, region: config.profileRegion });
   if (!idOrToken) {
-    idOrToken = await pickDeviceIDFromTagoIO(account);
+    idOrToken = await pickDeviceIDFromTagoIO(resources);
   }
-  const deviceInfo = await account.devices
+  const deviceInfo = await resources.devices
     .info(idOrToken)
     .catch(() => {
       const device = new Device({ token: idOrToken, region: config.profileRegion });
@@ -36,7 +37,8 @@ async function postDeviceData(idOrToken: string, options: IOptions) {
   }
 
   const data = JSON.parse(options.post);
-  const device = await Utils.getDevice(account, deviceInfo.id);
+  // Send through a device token: profile tokens cannot write device data.
+  const device = await getDeviceForSending(resources, deviceInfo.id, config.profileRegion);
   await device.sendData(data).then(successMSG).catch(errorHandler);
 }
 

--- a/src/commands/devices/device-bkp.test.ts
+++ b/src/commands/devices/device-bkp.test.ts
@@ -9,7 +9,6 @@ const getEnvironmentConfigMock = vi.fn();
 const errorHandlerMock = vi.fn((str: unknown): void => {
   throw new Error(String(str));
 });
-const getDeviceMock = vi.fn();
 const pickDeviceIDFromTagoIOMock = vi.fn();
 const pickFileFromTagoIOMock = vi.fn();
 const promptTextToEnterMock = vi.fn();
@@ -18,17 +17,22 @@ let fetchMock: ReturnType<typeof installFetchMock>;
 
 let accountInstance: ReturnType<typeof makeAccount>;
 
+const sendDataStreamingMock = vi.fn();
+
 vi.mock("@tago-io/sdk", () => ({
-  Account: function Account() {
+  Resources: function Resources() {
     return accountInstance;
   },
   Device: function Device() {
     return { info: vi.fn().mockRejectedValue(new Error("no device")) };
   },
   Utils: {
-    getDevice: (...args: unknown[]) => getDeviceMock(...args),
     uploadFile: (...args: unknown[]) => uploadFileMock(...args),
   },
+}));
+
+vi.mock("./device-sender.js", () => ({
+  getDeviceForSending: vi.fn(async () => ({ sendDataStreaming: sendDataStreamingMock })),
 }));
 
 vi.mock("../../lib/config-file.js", () => ({
@@ -78,7 +82,6 @@ describe("bkpDeviceData", () => {
     accountInstance = makeAccount();
     getEnvironmentConfigMock.mockReset();
     errorHandlerMock.mockClear();
-    getDeviceMock.mockReset();
     pickDeviceIDFromTagoIOMock.mockReset();
     pickFileFromTagoIOMock.mockReset();
     promptTextToEnterMock.mockReset();
@@ -112,9 +115,7 @@ describe("bkpDeviceData", () => {
       name: "Picked",
       created_at: new Date("2026-01-01"),
     });
-    getDeviceMock.mockResolvedValue({
-      getData: vi.fn().mockResolvedValue([]),
-    });
+    accountInstance.devices.getDeviceData.mockResolvedValue([]);
     promptTextToEnterMock.mockResolvedValue("./backup/file.json");
     uploadFileMock.mockResolvedValue(undefined);
 
@@ -123,39 +124,24 @@ describe("bkpDeviceData", () => {
     expect(pickDeviceIDFromTagoIOMock).toHaveBeenCalled();
   });
 
-  test("stops silently when getDevice returns null", async () => {
-    getEnvironmentConfigMock.mockReturnValue(makeEnvironmentConfig());
-    accountInstance.devices.info.mockResolvedValue({
-      id: "x",
-      name: "X",
-      created_at: new Date("2026-01-01"),
-    });
-    getDeviceMock.mockResolvedValue(null);
-
-    const { bkpDeviceData } = await import("./device-bkp.js");
-    const result = await bkpDeviceData("x", { environment: "prod", restore: false, local: false });
-    expect(result).toBeUndefined();
-  });
-
-  test("restore path with remote file downloads JSON and uploads data", async () => {
+  test("restore path with remote file downloads JSON and streams data back", async () => {
     getEnvironmentConfigMock.mockReturnValue(makeEnvironmentConfig());
     accountInstance.devices.info.mockResolvedValue({ id: "d1", name: "D1", created_at: new Date() });
     accountInstance.devices.emptyDeviceData.mockResolvedValue(undefined);
-    const sendDataStreaming = vi.fn().mockResolvedValue(undefined);
-    getDeviceMock.mockResolvedValue({ sendDataStreaming });
+    sendDataStreamingMock.mockResolvedValue(undefined);
     pickFileFromTagoIOMock.mockResolvedValue("http://example/backup.json");
     fetchMock.mockResolvedValue(makeFetchResponse([{ variable: "a", value: 1 }]));
 
     const { bkpDeviceData } = await import("./device-bkp.js");
     await bkpDeviceData("d1", { environment: "prod", restore: true, local: false });
     expect(accountInstance.devices.emptyDeviceData).toHaveBeenCalledWith("d1");
-    expect(sendDataStreaming).toHaveBeenCalled();
+    // Restore writes through the device token instance, not the profile token.
+    expect(sendDataStreamingMock).toHaveBeenCalledWith(expect.any(Array), expect.any(Object));
   });
 
   test("restore path errors out when remote file is not selected", async () => {
     getEnvironmentConfigMock.mockReturnValue(makeEnvironmentConfig());
     accountInstance.devices.info.mockResolvedValue({ id: "d1", name: "D1", created_at: new Date() });
-    getDeviceMock.mockResolvedValue({ sendDataStreaming: vi.fn() });
     pickFileFromTagoIOMock.mockResolvedValue("");
 
     const { bkpDeviceData } = await import("./device-bkp.js");
@@ -169,11 +155,10 @@ describe("bkpDeviceData", () => {
       name: "D1",
       created_at: new Date("2026-03-01"),
     });
-    const getData = vi.fn().mockResolvedValue([{ variable: "x", value: 1 }]);
-    getDeviceMock.mockResolvedValue({ getData });
+    accountInstance.devices.getDeviceData.mockResolvedValue([{ variable: "x", value: 1 }]);
 
     const { bkpDeviceData } = await import("./device-bkp.js");
     await bkpDeviceData("d1", { environment: "prod", restore: false, local: true });
-    expect(getData).toHaveBeenCalled();
+    expect(accountInstance.devices.getDeviceData).toHaveBeenCalled();
   });
 });

--- a/src/commands/devices/device-bkp.ts
+++ b/src/commands/devices/device-bkp.ts
@@ -1,4 +1,4 @@
-import { Account, Data, Device, DeviceInfo, DeviceItem, Utils } from "@tago-io/sdk";
+import { Data, Device, DeviceInfo, DeviceItem, Resources, Utils } from "@tago-io/sdk";
 import { readFileSync, writeFileSync } from "node:fs";
 import kleur from "kleur";
 import { DateTime } from "luxon";
@@ -10,6 +10,7 @@ import { printScopeBanner } from "../../lib/scope-notice.js";
 import { pickDeviceIDFromTagoIO } from "../../prompt/pick-device-id-from-tagoio.js";
 import { pickFileFromTagoIO } from "../../prompt/pick-files-from-tagoio.js";
 import { promptTextToEnter } from "../../prompt/text-prompt.js";
+import { getDeviceForSending } from "./device-sender.js";
 
 interface IOptions {
   environment?: string;
@@ -25,13 +26,13 @@ async function getJSON(url: string, authorization: string) {
   return response.json();
 }
 
-async function restoreBKP(account: Account, profileToken: string, device: Device, deviceInfo: DeviceInfo | DeviceItem, local: boolean) {
+async function restoreBKP(resources: Resources, profileToken: string, deviceInfo: DeviceInfo | DeviceItem, local: boolean, deviceRegion: ConstructorParameters<typeof Device>[0]["region"]) {
   const { name, id } = deviceInfo;
 
   let dataList: Data[] = [];
 
   if (!local) {
-    const fileName = await pickFileFromTagoIO(account);
+    const fileName = await pickFileFromTagoIO(resources);
     if (!fileName) {
       errorHandler("No file selected");
     }
@@ -44,12 +45,14 @@ async function restoreBKP(account: Account, profileToken: string, device: Device
     dataList = JSON.parse(readFileSync(filePath, "utf8"));
   }
 
-  await account.devices.emptyDeviceData(id);
+  await resources.devices.emptyDeviceData(id);
+  // Restore through a device token: profile tokens cannot write device data.
+  const device = await getDeviceForSending(resources, id, deviceRegion);
   await device.sendDataStreaming(dataList, { poolingRecordQty: 10_000, poolingTime: 1000 });
   successMSG(`> ${name} - ${dataList.length} data points`);
 }
 
-async function storeBKP(account: Account, device: Device, deviceInfo: DeviceInfo | DeviceItem, local: boolean) {
+async function storeBKP(resources: Resources, deviceInfo: DeviceInfo | DeviceItem, local: boolean) {
   const { created_at, name, id } = deviceInfo;
 
   // Start date with luxon at created_at and increase 1 month on a loop until today
@@ -61,8 +64,8 @@ async function storeBKP(account: Account, device: Device, deviceInfo: DeviceInfo
   for (let i = 0; i <= months; i++) {
     const month = startDate.plus({ months: i });
     const monthName = month.toFormat("yyyy-MM");
-    const monthData = await device
-      .getData({
+    const monthData = await resources.devices
+      .getDeviceData(id, {
         start_date: month.toISODate() as string,
         end_date: month.plus({ months: 1 }).toISODate() as string,
         qty: 10_000,
@@ -80,7 +83,7 @@ async function storeBKP(account: Account, device: Device, deviceInfo: DeviceInfo
 
   if (!local) {
     const filePath = await promptTextToEnter("Enter the file path to store the backup", `deviceBackup/${id}.json`);
-    await Utils.uploadFile(account, {
+    await Utils.uploadFile(resources, {
       filename: filePath,
       file_base64: Buffer.from(JSON.stringify(dataList, null, 4)).toString("base64"),
       public: true,
@@ -112,12 +115,12 @@ async function bkpDeviceData(idOrToken: string, options: IOptions) {
     errorHandler("Environment not found");
   }
 
-  const account = new Account({ token: config.profileToken, region: config.profileRegion });
+  const resources = new Resources({ token: config.profileToken, region: config.profileRegion });
   if (!idOrToken) {
-    idOrToken = await pickDeviceIDFromTagoIO(account);
+    idOrToken = await pickDeviceIDFromTagoIO(resources);
   }
 
-  const deviceInfo = await account.devices
+  const deviceInfo = await resources.devices
     .info(idOrToken)
     .catch(() => {
       const device = new Device({ token: idOrToken, region: config.profileRegion });
@@ -129,18 +132,13 @@ async function bkpDeviceData(idOrToken: string, options: IOptions) {
     return;
   }
 
-  const device = await Utils.getDevice(account, idOrToken).catch(errorHandler);
-  if (!device) {
-    return;
-  }
-
   if (options.restore) {
     infoMSG(`> Restoring data from ${deviceInfo.name}`);
-    return restoreBKP(account, config.profileToken, device, deviceInfo, options.local);
+    return restoreBKP(resources, config.profileToken, deviceInfo, options.local, config.profileRegion);
   }
 
   infoMSG(`> Backing up data from ${deviceInfo.name}`);
-  await storeBKP(account, device, deviceInfo, options.local);
+  await storeBKP(resources, deviceInfo, options.local);
 }
 
 export { bkpDeviceData };

--- a/src/commands/devices/device-create.test.ts
+++ b/src/commands/devices/device-create.test.ts
@@ -1,0 +1,169 @@
+import { afterEach, beforeEach, describe, expect, test, vi } from "vitest";
+
+import { makeEnvironmentConfig } from "../../test-utils/mock-config.js";
+import { makeAccount } from "../../test-utils/mock-sdk.js";
+
+const getEnvironmentConfigMock = vi.fn();
+const errorHandlerMock = vi.fn((str: unknown) => {
+  throw new Error(String(str));
+});
+const errorHandlerJSONMock = vi.fn((message: string, _code?: string) => {
+  throw new Error(`json:${message}`);
+});
+// Mirrors the real requireOrFail silent path: missing input routes through the
+// JSON/plain error handlers with the "missing_input" code.
+const requireOrFailMock = vi.fn(async (value: string | undefined, name: string, opts: { silent?: boolean; json?: boolean } = {}) => {
+  if (value) {
+    return value;
+  }
+  const message = `Missing required input: ${name}`;
+  if (opts.json) {
+    errorHandlerJSONMock(message, "missing_input");
+  }
+  errorHandlerMock(message);
+});
+
+let resourcesInstance: ReturnType<typeof makeAccount>;
+
+vi.mock("@tago-io/sdk", () => ({
+  Resources: function Resources() {
+    return resourcesInstance;
+  },
+}));
+
+vi.mock("../../lib/config-file.js", () => ({
+  getEnvironmentConfig: getEnvironmentConfigMock,
+}));
+
+vi.mock("../../lib/messages.js", () => ({
+  errorHandler: errorHandlerMock,
+  errorHandlerJSON: errorHandlerJSONMock,
+  requireOrFail: requireOrFailMock,
+  successMSG: vi.fn(),
+  infoMSG: vi.fn(),
+}));
+
+describe("deviceCreate", () => {
+  let stdoutSpy: ReturnType<typeof vi.spyOn>;
+
+  beforeEach(() => {
+    resourcesInstance = makeAccount();
+    getEnvironmentConfigMock.mockReset().mockReturnValue(makeEnvironmentConfig());
+    errorHandlerMock.mockClear();
+    errorHandlerJSONMock.mockClear();
+    requireOrFailMock.mockClear();
+    stdoutSpy = vi.spyOn(process.stdout, "write").mockImplementation(() => true);
+  });
+
+  afterEach(() => {
+    vi.restoreAllMocks();
+  });
+
+  test("creates a mutable device with network and connector", async () => {
+    resourcesInstance.devices.create.mockResolvedValue({ device_id: "dev-1", token: "tok-1" });
+
+    const { deviceCreate } = await import("./device-create.js");
+    await deviceCreate("Sensor A", {
+      type: "mutable",
+      network: "net-1",
+      connector: "con-1",
+    } as never);
+
+    expect(resourcesInstance.devices.create).toHaveBeenCalledWith(
+      expect.objectContaining({ name: "Sensor A", type: "mutable", network: "net-1", connector: "con-1" }),
+    );
+  });
+
+  test("immutable without chunk-period/retention errors with validation code", async () => {
+    const { deviceCreate } = await import("./device-create.js");
+    await expect(
+      deviceCreate("Imm", { type: "immutable", network: "net-1", connector: "con-1", json: true } as never),
+    ).rejects.toThrow(/json:/);
+    expect(errorHandlerJSONMock).toHaveBeenCalledWith(expect.stringContaining("chunk"), "missing_chunk_config");
+    expect(resourcesInstance.devices.create).not.toHaveBeenCalled();
+  });
+
+  test("immutable with chunk-period and chunk-retention is created", async () => {
+    resourcesInstance.devices.create.mockResolvedValue({ device_id: "dev-imm" });
+
+    const { deviceCreate } = await import("./device-create.js");
+    await deviceCreate("Imm", {
+      type: "immutable",
+      network: "net-1",
+      connector: "con-1",
+      chunkPeriod: "month",
+      chunkRetention: 3,
+    } as never);
+
+    expect(resourcesInstance.devices.create).toHaveBeenCalledWith(
+      expect.objectContaining({ type: "immutable", chunk_period: "month", chunk_retention: 3 }),
+    );
+  });
+
+  test("zips tag keys and values by index", async () => {
+    resourcesInstance.devices.create.mockResolvedValue({ device_id: "dev-t" });
+
+    const { deviceCreate } = await import("./device-create.js");
+    await deviceCreate("Tagged", {
+      type: "mutable",
+      network: "net-1",
+      connector: "con-1",
+      tagkey: ["type", "site"],
+      tagvalue: ["sensor", "hq"],
+    } as never);
+
+    expect(resourcesInstance.devices.create).toHaveBeenCalledWith(
+      expect.objectContaining({
+        tags: [{ key: "type", value: "sensor" }, { key: "site", value: "hq" }],
+      }),
+    );
+  });
+
+  test("--inactive creates the device inactive", async () => {
+    resourcesInstance.devices.create.mockResolvedValue({ device_id: "dev-i" });
+
+    const { deviceCreate } = await import("./device-create.js");
+    await deviceCreate("Off", {
+      type: "mutable",
+      network: "net-1",
+      connector: "con-1",
+      inactive: true,
+    } as never);
+
+    expect(resourcesInstance.devices.create).toHaveBeenCalledWith(
+      expect.objectContaining({ active: false }),
+    );
+  });
+
+  test("--json emits compact {id, name} from device_id", async () => {
+    resourcesInstance.devices.create.mockResolvedValue({ device_id: "json-dev", token: "t" });
+
+    const { deviceCreate } = await import("./device-create.js");
+    await deviceCreate("JC", {
+      type: "mutable",
+      network: "net-1",
+      connector: "con-1",
+      json: true,
+    } as never);
+
+    expect(stdoutSpy).toHaveBeenCalledOnce();
+    expect(JSON.parse(String(stdoutSpy.mock.calls[0][0]))).toEqual({ id: "json-dev", name: "JC", token: "t" });
+  });
+
+  test("--silent with missing network errors with missing_input", async () => {
+    const { deviceCreate } = await import("./device-create.js");
+    await expect(
+      deviceCreate("NoNet", { type: "mutable", connector: "con-1", silent: true, json: true } as never),
+    ).rejects.toThrow(/json:/);
+    expect(errorHandlerJSONMock).toHaveBeenCalledWith(expect.stringContaining("network"), "missing_input");
+  });
+
+  test("SDK failure routes through errorHandler", async () => {
+    resourcesInstance.devices.create.mockRejectedValue(new Error("boom"));
+
+    const { deviceCreate } = await import("./device-create.js");
+    await expect(
+      deviceCreate("X", { type: "mutable", network: "net-1", connector: "con-1" } as never),
+    ).rejects.toThrow(/Failed to create device: boom/);
+  });
+});

--- a/src/commands/devices/device-create.ts
+++ b/src/commands/devices/device-create.ts
@@ -1,0 +1,92 @@
+import { Resources, type TagsObj } from "@tago-io/sdk";
+
+import { getEnvironmentConfig } from "../../lib/config-file.js";
+import { errorHandler, errorHandlerJSON, requireOrFail, successMSG } from "../../lib/messages.js";
+
+interface IOptions {
+  environment?: string;
+  type?: "mutable" | "immutable";
+  network?: string;
+  connector?: string;
+  serie?: string;
+  description?: string;
+  chunkPeriod?: "day" | "week" | "month" | "quarter";
+  chunkRetention?: number;
+  tagkey?: string[];
+  tagvalue?: string[];
+  inactive?: boolean;
+  silent?: boolean;
+  json?: boolean;
+}
+
+function failWith(message: string, code: string, useJSON: boolean): never {
+  if (useJSON) {
+    errorHandlerJSON(message, code);
+  }
+  errorHandler(message);
+}
+
+/** Zips the repeatable `--tagkey`/`--tagvalue` arrays into the SDK tag shape, by index. */
+function buildTags(keys?: string[], values?: string[]): TagsObj[] | undefined {
+  if (!keys?.length) {
+    return undefined;
+  }
+  return keys.map((key, index) => ({ key, value: values?.[index] ?? "" }));
+}
+
+async function deviceCreate(nameArg: string | undefined, options: IOptions) {
+  const config = getEnvironmentConfig(options.environment);
+  if (!config || !config.profileToken) {
+    failWith("Environment not found", "env_not_found", Boolean(options.json));
+  }
+
+  const resources = new Resources({ token: config.profileToken, region: config.profileRegion });
+
+  const requireOpts = { silent: options.silent, json: options.json };
+  const name = await requireOrFail(nameArg, "name", { ...requireOpts, promptMessage: "Device name:" });
+  const type = options.type ?? "mutable";
+  const network = await requireOrFail(options.network, "network", { ...requireOpts, promptMessage: "Network ID:" });
+  const connector = await requireOrFail(options.connector, "connector", { ...requireOpts, promptMessage: "Connector ID:" });
+
+  // Immutable devices require a chunk policy; the API rejects them otherwise,
+  // so fail early with an actionable message instead of a generic API error.
+  if (type === "immutable" && (!options.chunkPeriod || options.chunkRetention === undefined)) {
+    failWith(
+      "Immutable devices require --chunk-period and --chunk-retention.",
+      "missing_chunk_config",
+      Boolean(options.json),
+    );
+  }
+
+  const tags = buildTags(options.tagkey, options.tagvalue);
+
+  const payload = {
+    name,
+    type,
+    network,
+    connector,
+    active: !options.inactive,
+    ...(options.serie ? { serie_number: options.serie } : {}),
+    ...(options.description ? { description: options.description } : {}),
+    ...(type === "immutable" ? { chunk_period: options.chunkPeriod, chunk_retention: options.chunkRetention } : {}),
+    ...(tags ? { tags } : {}),
+  };
+
+  const created = await resources.devices.create(payload as never).catch((error: unknown) => {
+    const message = error instanceof Error ? error.message : String(error);
+    failWith(`Failed to create device: ${message}`, "create_failed", Boolean(options.json));
+  });
+
+  if (!created) {
+    return;
+  }
+
+  if (options.json) {
+    process.stdout.write(`${JSON.stringify({ id: created.device_id, name, token: created.token })}\n`);
+    return;
+  }
+
+  successMSG(`Device created: ${name} [${created.device_id}].`);
+}
+
+export { deviceCreate, buildTags };

--- a/src/commands/devices/device-delete.test.ts
+++ b/src/commands/devices/device-delete.test.ts
@@ -1,0 +1,116 @@
+import prompts from "prompts";
+import { afterEach, beforeEach, describe, expect, test, vi } from "vitest";
+
+import { makeEnvironmentConfig } from "../../test-utils/mock-config.js";
+import { makeAccount } from "../../test-utils/mock-sdk.js";
+
+const getEnvironmentConfigMock = vi.fn();
+const errorHandlerMock = vi.fn((str: unknown) => {
+  throw new Error(String(str));
+});
+const errorHandlerJSONMock = vi.fn((message: string, _code?: string) => {
+  throw new Error(`json:${message}`);
+});
+const pickDeviceIDMock = vi.fn();
+
+let resourcesInstance: ReturnType<typeof makeAccount>;
+
+vi.mock("@tago-io/sdk", () => ({
+  Resources: function Resources() {
+    return resourcesInstance;
+  },
+}));
+
+vi.mock("../../lib/config-file.js", () => ({
+  getEnvironmentConfig: getEnvironmentConfigMock,
+}));
+
+vi.mock("../../lib/messages.js", () => ({
+  errorHandler: errorHandlerMock,
+  errorHandlerJSON: errorHandlerJSONMock,
+  successMSG: vi.fn(),
+}));
+
+vi.mock("../../prompt/pick-device-id-from-tagoio.js", () => ({
+  pickDeviceIDFromTagoIO: pickDeviceIDMock,
+}));
+
+describe("deviceDelete", () => {
+  let stdoutSpy: ReturnType<typeof vi.spyOn>;
+
+  beforeEach(() => {
+    resourcesInstance = makeAccount();
+    getEnvironmentConfigMock.mockReset().mockReturnValue(makeEnvironmentConfig());
+    errorHandlerMock.mockClear();
+    errorHandlerJSONMock.mockClear();
+    pickDeviceIDMock.mockReset();
+    stdoutSpy = vi.spyOn(process.stdout, "write").mockImplementation(() => true);
+  });
+
+  afterEach(() => {
+    vi.restoreAllMocks();
+  });
+
+  test("deletes after the user confirms", async () => {
+    resourcesInstance.devices.delete.mockResolvedValue("deleted");
+    prompts.inject([true]);
+
+    const { deviceDelete } = await import("./device-delete.js");
+    await deviceDelete("dev-1", {} as never);
+
+    expect(resourcesInstance.devices.delete).toHaveBeenCalledWith("dev-1");
+  });
+
+  test("declining the confirmation makes no delete call", async () => {
+    prompts.inject([false]);
+
+    const { deviceDelete } = await import("./device-delete.js");
+    await deviceDelete("dev-1", {} as never);
+
+    expect(resourcesInstance.devices.delete).not.toHaveBeenCalled();
+  });
+
+  test("-y skips the confirmation", async () => {
+    resourcesInstance.devices.delete.mockResolvedValue("deleted");
+
+    const { deviceDelete } = await import("./device-delete.js");
+    await deviceDelete("dev-1", { yes: true } as never);
+
+    expect(resourcesInstance.devices.delete).toHaveBeenCalledWith("dev-1");
+  });
+
+  test("picks an id interactively when none is given", async () => {
+    resourcesInstance.devices.delete.mockResolvedValue("deleted");
+    pickDeviceIDMock.mockResolvedValue("picked-dev");
+    prompts.inject([true]);
+
+    const { deviceDelete } = await import("./device-delete.js");
+    await deviceDelete(undefined, {} as never);
+
+    expect(pickDeviceIDMock).toHaveBeenCalled();
+    expect(resourcesInstance.devices.delete).toHaveBeenCalledWith("picked-dev");
+  });
+
+  test("--silent with no id errors with missing_input", async () => {
+    const { deviceDelete } = await import("./device-delete.js");
+    await expect(deviceDelete(undefined, { silent: true, json: true } as never)).rejects.toThrow(/json:/);
+    expect(errorHandlerJSONMock).toHaveBeenCalledWith(expect.stringContaining("id"), "missing_input");
+    expect(pickDeviceIDMock).not.toHaveBeenCalled();
+  });
+
+  test("--json emits {id, deleted:true}", async () => {
+    resourcesInstance.devices.delete.mockResolvedValue("deleted");
+
+    const { deviceDelete } = await import("./device-delete.js");
+    await deviceDelete("dev-j", { yes: true, json: true } as never);
+
+    expect(JSON.parse(String(stdoutSpy.mock.calls[0][0]))).toEqual({ id: "dev-j", deleted: true });
+  });
+
+  test("SDK failure routes through errorHandler", async () => {
+    resourcesInstance.devices.delete.mockRejectedValue(new Error("boom"));
+
+    const { deviceDelete } = await import("./device-delete.js");
+    await expect(deviceDelete("dev-x", { yes: true } as never)).rejects.toThrow(/Failed to delete device dev-x: boom/);
+  });
+});

--- a/src/commands/devices/device-delete.ts
+++ b/src/commands/devices/device-delete.ts
@@ -1,0 +1,65 @@
+import { Resources } from "@tago-io/sdk";
+import prompts from "prompts";
+
+import { getEnvironmentConfig } from "../../lib/config-file.js";
+import { errorHandler, errorHandlerJSON, successMSG } from "../../lib/messages.js";
+import { pickDeviceIDFromTagoIO } from "../../prompt/pick-device-id-from-tagoio.js";
+
+interface IOptions {
+  environment?: string;
+  silent?: boolean;
+  json?: boolean;
+  yes?: boolean;
+}
+
+function failWith(message: string, code: string, useJSON: boolean): never {
+  if (useJSON) {
+    errorHandlerJSON(message, code);
+  }
+  errorHandler(message);
+}
+
+async function deviceDelete(idArg: string | undefined, options: IOptions) {
+  const config = getEnvironmentConfig(options.environment);
+  if (!config || !config.profileToken) {
+    failWith("Environment not found", "env_not_found", Boolean(options.json));
+  }
+
+  const resources = new Resources({ token: config.profileToken, region: config.profileRegion });
+
+  let id = idArg;
+  if (!id) {
+    if (options.silent) {
+      failWith("Missing required input: id", "missing_input", Boolean(options.json));
+    }
+    id = await pickDeviceIDFromTagoIO(resources);
+  }
+
+  // Destructive op: confirm unless --silent or -y.
+  if (!options.silent && !options.yes) {
+    const { confirm } = await prompts({
+      type: "confirm",
+      name: "confirm",
+      message: `Permanently delete device ${id}? This cannot be undone.`,
+      initial: false,
+    });
+    if (confirm !== true) {
+      successMSG("Cancelled. No changes made.");
+      return;
+    }
+  }
+
+  await resources.devices.delete(id).catch((error: unknown) => {
+    const message = error instanceof Error ? error.message : String(error);
+    failWith(`Failed to delete device ${id}: ${message}`, "delete_failed", Boolean(options.json));
+  });
+
+  if (options.json) {
+    process.stdout.write(`${JSON.stringify({ id, deleted: true })}\n`);
+    return;
+  }
+
+  successMSG(`Device ${id} deleted.`);
+}
+
+export { deviceDelete };

--- a/src/commands/devices/device-edit.test.ts
+++ b/src/commands/devices/device-edit.test.ts
@@ -1,0 +1,143 @@
+import { afterEach, beforeEach, describe, expect, test, vi } from "vitest";
+
+import { makeEnvironmentConfig } from "../../test-utils/mock-config.js";
+import { makeAccount } from "../../test-utils/mock-sdk.js";
+
+const getEnvironmentConfigMock = vi.fn();
+const errorHandlerMock = vi.fn((str: unknown) => {
+  throw new Error(String(str));
+});
+const errorHandlerJSONMock = vi.fn((message: string, _code?: string) => {
+  throw new Error(`json:${message}`);
+});
+const pickDeviceIDMock = vi.fn();
+
+let resourcesInstance: ReturnType<typeof makeAccount>;
+
+vi.mock("@tago-io/sdk", () => ({
+  Resources: function Resources() {
+    return resourcesInstance;
+  },
+}));
+
+vi.mock("../../lib/config-file.js", () => ({
+  getEnvironmentConfig: getEnvironmentConfigMock,
+}));
+
+vi.mock("../../lib/messages.js", () => ({
+  errorHandler: errorHandlerMock,
+  errorHandlerJSON: errorHandlerJSONMock,
+  successMSG: vi.fn(),
+}));
+
+vi.mock("../../prompt/pick-device-id-from-tagoio.js", () => ({
+  pickDeviceIDFromTagoIO: pickDeviceIDMock,
+}));
+
+describe("deviceEdit", () => {
+  let stdoutSpy: ReturnType<typeof vi.spyOn>;
+
+  beforeEach(() => {
+    resourcesInstance = makeAccount();
+    getEnvironmentConfigMock.mockReset().mockReturnValue(makeEnvironmentConfig());
+    errorHandlerMock.mockClear();
+    errorHandlerJSONMock.mockClear();
+    pickDeviceIDMock.mockReset();
+    stdoutSpy = vi.spyOn(process.stdout, "write").mockImplementation(() => true);
+  });
+
+  afterEach(() => {
+    vi.restoreAllMocks();
+  });
+
+  test("edits the device name", async () => {
+    resourcesInstance.devices.edit.mockResolvedValue("updated");
+
+    const { deviceEdit } = await import("./device-edit.js");
+    await deviceEdit("dev-1", { name: "Renamed" } as never);
+
+    expect(resourcesInstance.devices.edit).toHaveBeenCalledWith("dev-1", expect.objectContaining({ name: "Renamed" }));
+  });
+
+  test("no edit fields → no_changes error, no SDK call", async () => {
+    const { deviceEdit } = await import("./device-edit.js");
+    await expect(deviceEdit("dev-1", { json: true } as never)).rejects.toThrow(/json:/);
+    expect(errorHandlerJSONMock).toHaveBeenCalledWith(expect.any(String), "no_changes");
+    expect(resourcesInstance.devices.edit).not.toHaveBeenCalled();
+  });
+
+  test("--active and --inactive set the active flag", async () => {
+    resourcesInstance.devices.edit.mockResolvedValue("updated");
+
+    const { deviceEdit } = await import("./device-edit.js");
+    await deviceEdit("dev-1", { inactive: true } as never);
+
+    expect(resourcesInstance.devices.edit).toHaveBeenCalledWith("dev-1", expect.objectContaining({ active: false }));
+  });
+
+  test("default tag behavior replaces the whole tag set", async () => {
+    resourcesInstance.devices.edit.mockResolvedValue("updated");
+
+    const { deviceEdit } = await import("./device-edit.js");
+    await deviceEdit("dev-1", { tagkey: ["type"], tagvalue: ["sensor"] } as never);
+
+    expect(resourcesInstance.devices.info).not.toHaveBeenCalled();
+    expect(resourcesInstance.devices.edit).toHaveBeenCalledWith(
+      "dev-1",
+      expect.objectContaining({ tags: [{ key: "type", value: "sensor" }] }),
+    );
+  });
+
+  test("--merge-tags merges new tags into existing ones, overriding matching keys", async () => {
+    resourcesInstance.devices.info.mockResolvedValue({
+      tags: [{ key: "type", value: "old" }, { key: "site", value: "hq" }],
+    });
+    resourcesInstance.devices.edit.mockResolvedValue("updated");
+
+    const { deviceEdit } = await import("./device-edit.js");
+    await deviceEdit("dev-1", { tagkey: ["type", "zone"], tagvalue: ["sensor", "a"], mergeTags: true } as never);
+
+    expect(resourcesInstance.devices.info).toHaveBeenCalledWith("dev-1");
+    const sentTags = resourcesInstance.devices.edit.mock.calls[0][1].tags;
+    expect(sentTags).toEqual(
+      expect.arrayContaining([
+        { key: "type", value: "sensor" },
+        { key: "site", value: "hq" },
+        { key: "zone", value: "a" },
+      ]),
+    );
+    expect(sentTags).toHaveLength(3);
+  });
+
+  test("--json emits {id, updated:true}", async () => {
+    resourcesInstance.devices.edit.mockResolvedValue("updated");
+
+    const { deviceEdit } = await import("./device-edit.js");
+    await deviceEdit("dev-j", { name: "N", json: true } as never);
+
+    expect(JSON.parse(String(stdoutSpy.mock.calls[0][0]))).toEqual({ id: "dev-j", updated: true });
+  });
+
+  test("--silent with no id errors with missing_input", async () => {
+    const { deviceEdit } = await import("./device-edit.js");
+    await expect(deviceEdit(undefined, { name: "x", silent: true, json: true } as never)).rejects.toThrow(/json:/);
+    expect(errorHandlerJSONMock).toHaveBeenCalledWith(expect.stringContaining("id"), "missing_input");
+  });
+
+  test("SDK failure routes through errorHandler", async () => {
+    resourcesInstance.devices.edit.mockRejectedValue(new Error("boom"));
+
+    const { deviceEdit } = await import("./device-edit.js");
+    await expect(deviceEdit("dev-x", { name: "x" } as never)).rejects.toThrow(/Failed to edit device dev-x: boom/);
+  });
+
+  test("applyDeviceEdit is exported and performs the edit + json output", async () => {
+    resourcesInstance.devices.edit.mockResolvedValue("updated");
+
+    const { applyDeviceEdit } = await import("./device-edit.js");
+    await applyDeviceEdit(resourcesInstance as never, "dev-h", { network: "n", connector: "c" }, { json: true });
+
+    expect(resourcesInstance.devices.edit).toHaveBeenCalledWith("dev-h", { network: "n", connector: "c" });
+    expect(JSON.parse(String(stdoutSpy.mock.calls[0][0]))).toEqual({ id: "dev-h", updated: true });
+  });
+});

--- a/src/commands/devices/device-edit.ts
+++ b/src/commands/devices/device-edit.ts
@@ -1,0 +1,121 @@
+import { Resources, type DeviceEditInfo, type TagsObj } from "@tago-io/sdk";
+
+import { getEnvironmentConfig } from "../../lib/config-file.js";
+import { errorHandler, errorHandlerJSON, successMSG } from "../../lib/messages.js";
+import { pickDeviceIDFromTagoIO } from "../../prompt/pick-device-id-from-tagoio.js";
+
+interface IOptions {
+  environment?: string;
+  name?: string;
+  description?: string;
+  active?: boolean;
+  inactive?: boolean;
+  network?: string;
+  connector?: string;
+  chunkRetention?: number;
+  tagkey?: string[];
+  tagvalue?: string[];
+  mergeTags?: boolean;
+  silent?: boolean;
+  json?: boolean;
+}
+
+interface OutputOptions {
+  json?: boolean;
+}
+
+function failWith(message: string, code: string, useJSON: boolean): never {
+  if (useJSON) {
+    errorHandlerJSON(message, code);
+  }
+  errorHandler(message);
+}
+
+/** Zips the repeatable `--tagkey`/`--tagvalue` arrays into the SDK tag shape, by index. */
+function buildTagPairs(keys?: string[], values?: string[]): TagsObj[] {
+  return (keys ?? []).map((key, index) => ({ key, value: values?.[index] ?? "" }));
+}
+
+/** Merges new tags into existing ones, overriding by key. */
+function mergeTags(existing: TagsObj[], incoming: TagsObj[]): TagsObj[] {
+  const byKey = new Map(existing.map((tag) => [tag.key, tag.value]));
+  for (const tag of incoming) {
+    byKey.set(tag.key, tag.value);
+  }
+  return [...byKey].map(([key, value]) => ({ key, value }));
+}
+
+/**
+ * @description Shared edit path: applies a DeviceEditInfo patch to a device and
+ * reports the result. `device-network` reuses this so both commands edit through
+ * one code path.
+ */
+async function applyDeviceEdit(resources: Resources, id: string, patch: DeviceEditInfo, options: OutputOptions = {}) {
+  await resources.devices.edit(id, patch).catch((error: unknown) => {
+    const message = error instanceof Error ? error.message : String(error);
+    failWith(`Failed to edit device ${id}: ${message}`, "edit_failed", Boolean(options.json));
+  });
+
+  if (options.json) {
+    process.stdout.write(`${JSON.stringify({ id, updated: true })}\n`);
+    return;
+  }
+
+  successMSG(`Device ${id} updated.`);
+}
+
+async function deviceEdit(idArg: string | undefined, options: IOptions) {
+  const config = getEnvironmentConfig(options.environment);
+  if (!config || !config.profileToken) {
+    failWith("Environment not found", "env_not_found", Boolean(options.json));
+  }
+
+  const resources = new Resources({ token: config.profileToken, region: config.profileRegion });
+
+  let id = idArg;
+  if (!id) {
+    if (options.silent) {
+      failWith("Missing required input: id", "missing_input", Boolean(options.json));
+    }
+    id = await pickDeviceIDFromTagoIO(resources);
+  }
+
+  // Build the patch from only the flags the user set.
+  const patch: DeviceEditInfo = {};
+  if (options.name !== undefined) {
+    patch.name = options.name;
+  }
+  if (options.description !== undefined) {
+    patch.description = options.description;
+  }
+  if (options.active || options.inactive) {
+    patch.active = Boolean(options.active) && !options.inactive;
+  }
+  if (options.network !== undefined) {
+    patch.network = options.network;
+  }
+  if (options.connector !== undefined) {
+    patch.connector = options.connector;
+  }
+  if (options.chunkRetention !== undefined) {
+    patch.chunk_retention = options.chunkRetention;
+  }
+
+  if (options.tagkey?.length) {
+    const incoming = buildTagPairs(options.tagkey, options.tagvalue);
+    if (options.mergeTags) {
+      const info = await resources.devices.info(id);
+      patch.tags = mergeTags(info?.tags ?? [], incoming);
+    } else {
+      patch.tags = incoming;
+    }
+  }
+
+  if (Object.keys(patch).length === 0) {
+    failWith("Nothing to update — pass at least one field to edit.", "no_changes", Boolean(options.json));
+  }
+
+  await applyDeviceEdit(resources, id, patch, { json: options.json });
+}
+
+export { deviceEdit, applyDeviceEdit, mergeTags, buildTagPairs };

--- a/src/commands/devices/device-info.test.ts
+++ b/src/commands/devices/device-info.test.ts
@@ -9,16 +9,19 @@ const accountTokenListMock = vi.fn();
 const deviceInfoMock = vi.fn();
 const pickDeviceIDFromTagoIOMock = vi.fn();
 
+function makeDevicesNamespace() {
+  return {
+    devices: {
+      info: accountInfoMock,
+      paramList: accountParamListMock,
+      tokenList: accountTokenListMock,
+    },
+  };
+}
+
 vi.mock("@tago-io/sdk", () => ({
-  Account: vi.fn(function Account() {
-    return {
-      devices: {
-        info: accountInfoMock,
-        paramList: accountParamListMock,
-        tokenList: accountTokenListMock,
-      },
-    };
-  }),
+  Resources: vi.fn(makeDevicesNamespace),
+  Account: vi.fn(makeDevicesNamespace),
   Device: vi.fn(function Device() {
     return { info: deviceInfoMock };
   }),

--- a/src/commands/devices/device-info.ts
+++ b/src/commands/devices/device-info.ts
@@ -1,4 +1,4 @@
-import { Account, Device, DeviceInfo } from "@tago-io/sdk";
+import { Device, DeviceInfo, Resources } from "@tago-io/sdk";
 
 import { getEnvironmentConfig } from "../../lib/config-file.js";
 import { errorHandler, infoMSG } from "../../lib/messages.js";
@@ -11,11 +11,11 @@ async function deviceInfo(idOrToken: string, options: { environment: string; raw
     errorHandler("Environment not found");
   }
 
-  const account = new Account({ token: config.profileToken, region: config.profileRegion });
+  const resources = new Resources({ token: config.profileToken, region: config.profileRegion });
   if (!idOrToken) {
-    idOrToken = await pickDeviceIDFromTagoIO(account);
+    idOrToken = await pickDeviceIDFromTagoIO(resources);
   }
-  let deviceInfo = await account.devices.info(idOrToken).catch(() => null);
+  let deviceInfo = await resources.devices.info(idOrToken).catch(() => null);
   if (!deviceInfo) {
     const device = new Device({ token: idOrToken });
     deviceInfo = await device
@@ -31,10 +31,10 @@ async function deviceInfo(idOrToken: string, options: { environment: string; raw
   }
 
   infoMSG(`Device Found: ${deviceInfo.name} [${deviceInfo.id}].`);
-  const paramList = await account.devices.paramList(idOrToken);
+  const paramList = await resources.devices.paramList(idOrToken);
 
   if (options.tokens) {
-    const tokenList = await account.devices.tokenList(idOrToken, { fields: ["name", "token", "last_authorization", "serie_number"] });
+    const tokenList = await resources.devices.tokenList(idOrToken, { fields: ["name", "token", "last_authorization", "serie_number"] });
     //@ts-expect-error ignore error
     deviceInfo.tokens = tokenList;
   }

--- a/src/commands/devices/device-list.test.ts
+++ b/src/commands/devices/device-list.test.ts
@@ -10,7 +10,7 @@ const errorHandlerMock = vi.fn((str: unknown): void => {
 const devicesListMock = vi.fn();
 
 vi.mock("@tago-io/sdk", () => ({
-  Account: function Account() {
+  Resources: function Resources() {
     return {
       devices: { list: (...args: unknown[]) => devicesListMock(...args) },
     };

--- a/src/commands/devices/device-list.ts
+++ b/src/commands/devices/device-list.ts
@@ -1,4 +1,4 @@
-import { Account, DeviceQuery, TagsObj } from "@tago-io/sdk";
+import { DeviceQuery, Resources, TagsObj } from "@tago-io/sdk";
 import kleur from "kleur";
 
 import { getEnvironmentConfig } from "../../lib/config-file.js";
@@ -77,14 +77,14 @@ async function deviceList(options: IOptions) {
     errorHandler("Environment not found");
   }
 
-  const account = new Account({ token: config.profileToken, region: config.profileRegion });
+  const resources = new Resources({ token: config.profileToken, region: config.profileRegion });
   const filter: DeviceQuery = { amount: 50, fields: ["id", "name", "active", "last_input"], filter: { tags: [{}] } };
   if (filter.filter && options.name) {
     filter.filter.name = `*${options.name}*`;
   }
 
   repeatableTags(filter, { keys: options.tagkey, values: options.tagvalue });
-  const deviceList = await account.devices.list(filter).catch(errorHandler);
+  const deviceList = await resources.devices.list(filter).catch(errorHandler);
   if (!deviceList) {
     return;
   }

--- a/src/commands/devices/device-live-inspector.test.ts
+++ b/src/commands/devices/device-live-inspector.test.ts
@@ -14,7 +14,7 @@ const errorHandlerMock = vi.fn((str: unknown): void => {
 let accountInstance: ReturnType<typeof makeAccount>;
 
 vi.mock("@tago-io/sdk", () => ({
-  Account: function Account() {
+  Resources: function Resources() {
     return accountInstance;
   },
   Device: function Device() {

--- a/src/commands/devices/device-live-inspector.ts
+++ b/src/commands/devices/device-live-inspector.ts
@@ -1,4 +1,4 @@
-import { Account, Device, DeviceInfo } from "@tago-io/sdk";
+import { Device, DeviceInfo, Resources } from "@tago-io/sdk";
 import { EventSource } from "eventsource";
 
 import { getEnvironmentConfig } from "../../lib/config-file.js";
@@ -89,12 +89,12 @@ async function inspectorConnection(deviceIdOrToken: string, options: IOptions) {
     errorHandler("Environment not found");
   }
 
-  const account = new Account({ token: config.profileToken, region: config.profileRegion });
+  const resources = new Resources({ token: config.profileToken, region: config.profileRegion });
   if (!deviceIdOrToken) {
-    deviceIdOrToken = await pickDeviceIDFromTagoIO(account);
+    deviceIdOrToken = await pickDeviceIDFromTagoIO(resources);
   }
 
-  let deviceInfo = await account.devices.info(deviceIdOrToken).catch(() => null);
+  let deviceInfo = await resources.devices.info(deviceIdOrToken).catch(() => null);
   if (!deviceInfo) {
     const device = new Device({ token: deviceIdOrToken, region: config.profileRegion });
     deviceInfo = await device

--- a/src/commands/devices/device-param.test.ts
+++ b/src/commands/devices/device-param.test.ts
@@ -1,0 +1,126 @@
+import { afterEach, beforeEach, describe, expect, test, vi } from "vitest";
+
+import { makeEnvironmentConfig } from "../../test-utils/mock-config.js";
+import { makeAccount } from "../../test-utils/mock-sdk.js";
+
+const getEnvironmentConfigMock = vi.fn();
+const errorHandlerMock = vi.fn((str: unknown) => {
+  throw new Error(String(str));
+});
+const errorHandlerJSONMock = vi.fn((message: string, _code?: string) => {
+  throw new Error(`json:${message}`);
+});
+const pickDeviceIDMock = vi.fn();
+
+let resourcesInstance: ReturnType<typeof makeAccount>;
+
+vi.mock("@tago-io/sdk", () => ({
+  Resources: function Resources() {
+    return resourcesInstance;
+  },
+}));
+
+vi.mock("../../lib/config-file.js", () => ({
+  getEnvironmentConfig: getEnvironmentConfigMock,
+}));
+
+vi.mock("../../lib/messages.js", () => ({
+  errorHandler: errorHandlerMock,
+  errorHandlerJSON: errorHandlerJSONMock,
+  successMSG: vi.fn(),
+  infoMSG: vi.fn(),
+}));
+
+vi.mock("../../prompt/pick-device-id-from-tagoio.js", () => ({
+  pickDeviceIDFromTagoIO: pickDeviceIDMock,
+}));
+
+describe("deviceParam", () => {
+  let stdoutSpy: ReturnType<typeof vi.spyOn>;
+
+  beforeEach(() => {
+    resourcesInstance = makeAccount();
+    getEnvironmentConfigMock.mockReset().mockReturnValue(makeEnvironmentConfig());
+    errorHandlerMock.mockClear();
+    errorHandlerJSONMock.mockClear();
+    pickDeviceIDMock.mockReset();
+    stdoutSpy = vi.spyOn(process.stdout, "write").mockImplementation(() => true);
+    vi.spyOn(console, "table").mockImplementation(() => undefined);
+  });
+
+  afterEach(() => {
+    vi.restoreAllMocks();
+  });
+
+  test("--set upserts params with sent=false by default", async () => {
+    resourcesInstance.devices.paramSet.mockResolvedValue("ok");
+
+    const { deviceParam } = await import("./device-param.js");
+    await deviceParam("dev-1", { set: ["a=1", "b=2"] } as never);
+
+    expect(resourcesInstance.devices.paramSet).toHaveBeenCalledWith("dev-1", [
+      { key: "a", value: "1", sent: false },
+      { key: "b", value: "2", sent: false },
+    ]);
+  });
+
+  test("--sent marks set params as sent", async () => {
+    resourcesInstance.devices.paramSet.mockResolvedValue("ok");
+
+    const { deviceParam } = await import("./device-param.js");
+    await deviceParam("dev-1", { set: ["a=1"], sent: true } as never);
+
+    expect(resourcesInstance.devices.paramSet).toHaveBeenCalledWith("dev-1", [{ key: "a", value: "1", sent: true }]);
+  });
+
+  test("value may contain '=' (split on first only)", async () => {
+    resourcesInstance.devices.paramSet.mockResolvedValue("ok");
+
+    const { deviceParam } = await import("./device-param.js");
+    await deviceParam("dev-1", { set: ["url=https://x.io/a=b"] } as never);
+
+    expect(resourcesInstance.devices.paramSet).toHaveBeenCalledWith("dev-1", [
+      { key: "url", value: "https://x.io/a=b", sent: false },
+    ]);
+  });
+
+  test("malformed --set (no '=') errors with invalid_param", async () => {
+    const { deviceParam } = await import("./device-param.js");
+    await expect(deviceParam("dev-1", { set: ["broken"], json: true } as never)).rejects.toThrow(/json:/);
+    expect(errorHandlerJSONMock).toHaveBeenCalledWith(expect.stringContaining("broken"), "invalid_param");
+    expect(resourcesInstance.devices.paramSet).not.toHaveBeenCalled();
+  });
+
+  test("--delete removes a param by id", async () => {
+    resourcesInstance.devices.paramRemove.mockResolvedValue("removed");
+
+    const { deviceParam } = await import("./device-param.js");
+    await deviceParam("dev-1", { delete: "param-1" } as never);
+
+    expect(resourcesInstance.devices.paramRemove).toHaveBeenCalledWith("dev-1", "param-1");
+  });
+
+  test("no op flag lists params (default)", async () => {
+    const params = [{ id: "p1", key: "a", value: "1", sent: false }];
+    resourcesInstance.devices.paramList.mockResolvedValue(params);
+
+    const { deviceParam } = await import("./device-param.js");
+    await deviceParam("dev-1", { json: true } as never);
+
+    expect(resourcesInstance.devices.paramList).toHaveBeenCalledWith("dev-1");
+    expect(JSON.parse(String(stdoutSpy.mock.calls[0][0]))).toEqual(params);
+  });
+
+  test("--silent with no id errors with missing_input", async () => {
+    const { deviceParam } = await import("./device-param.js");
+    await expect(deviceParam(undefined, { set: ["a=1"], silent: true, json: true } as never)).rejects.toThrow(/json:/);
+    expect(errorHandlerJSONMock).toHaveBeenCalledWith(expect.stringContaining("id"), "missing_input");
+  });
+
+  test("SDK failure on set routes through errorHandler", async () => {
+    resourcesInstance.devices.paramSet.mockRejectedValue(new Error("boom"));
+
+    const { deviceParam } = await import("./device-param.js");
+    await expect(deviceParam("dev-x", { set: ["a=1"] } as never)).rejects.toThrow(/Failed to set params: boom/);
+  });
+});

--- a/src/commands/devices/device-param.ts
+++ b/src/commands/devices/device-param.ts
@@ -1,0 +1,93 @@
+import { Resources, type ConfigurationParams } from "@tago-io/sdk";
+
+import { getEnvironmentConfig } from "../../lib/config-file.js";
+import { errorHandler, errorHandlerJSON, infoMSG, successMSG } from "../../lib/messages.js";
+import { pickDeviceIDFromTagoIO } from "../../prompt/pick-device-id-from-tagoio.js";
+
+interface IOptions {
+  environment?: string;
+  set?: string[];
+  sent?: boolean;
+  delete?: string;
+  list?: boolean;
+  silent?: boolean;
+  json?: boolean;
+}
+
+function failWith(message: string, code: string, useJSON: boolean): never {
+  if (useJSON) {
+    errorHandlerJSON(message, code);
+  }
+  errorHandler(message);
+}
+
+/** Parses `key=value` (split on the first `=` only, so values may contain `=`). */
+function parseParam(input: string, sent: boolean, useJSON: boolean): ConfigurationParams {
+  const splitAt = input.indexOf("=");
+  if (splitAt === -1) {
+    failWith(`Invalid --set "${input}". Expected key=value.`, "invalid_param", useJSON);
+  }
+  return { key: input.slice(0, splitAt), value: input.slice(splitAt + 1), sent };
+}
+
+async function deviceParam(idArg: string | undefined, options: IOptions) {
+  const config = getEnvironmentConfig(options.environment);
+  if (!config || !config.profileToken) {
+    failWith("Environment not found", "env_not_found", Boolean(options.json));
+  }
+
+  const resources = new Resources({ token: config.profileToken, region: config.profileRegion });
+
+  let id = idArg;
+  if (!id) {
+    if (options.silent) {
+      failWith("Missing required input: id", "missing_input", Boolean(options.json));
+    }
+    id = await pickDeviceIDFromTagoIO(resources);
+  }
+
+  if (options.set?.length) {
+    const params = options.set.map((pair) => parseParam(pair, Boolean(options.sent), Boolean(options.json)));
+    await resources.devices.paramSet(id, params).catch((error: unknown) => {
+      const message = error instanceof Error ? error.message : String(error);
+      failWith(`Failed to set params: ${message}`, "param_set_failed", Boolean(options.json));
+    });
+    if (options.json) {
+      process.stdout.write(`${JSON.stringify({ id, set: params })}\n`);
+      return;
+    }
+    successMSG(`${params.length} param(s) set on device ${id}.`);
+    return;
+  }
+
+  if (options.delete) {
+    const paramID = options.delete;
+    await resources.devices.paramRemove(id, paramID).catch((error: unknown) => {
+      const message = error instanceof Error ? error.message : String(error);
+      failWith(`Failed to delete param: ${message}`, "param_delete_failed", Boolean(options.json));
+    });
+    if (options.json) {
+      process.stdout.write(`${JSON.stringify({ id, param: paramID, deleted: true })}\n`);
+      return;
+    }
+    successMSG(`Param ${paramID} deleted from device ${id}.`);
+    return;
+  }
+
+  // Default op: list params.
+  const params = await resources.devices.paramList(id).catch((error: unknown) => {
+    const message = error instanceof Error ? error.message : String(error);
+    failWith(`Failed to list params: ${message}`, "param_list_failed", Boolean(options.json));
+  });
+  if (!params) {
+    return;
+  }
+  if (options.json) {
+    process.stdout.write(`${JSON.stringify(params)}\n`);
+    return;
+  }
+  console.table(params);
+  infoMSG(`${params.length} param(s) found for device ${id}.`);
+}
+
+export { deviceParam, parseParam };

--- a/src/commands/devices/device-sender.ts
+++ b/src/commands/devices/device-sender.ts
@@ -1,0 +1,24 @@
+import { Device, Resources } from "@tago-io/sdk";
+
+import { errorHandler } from "../../lib/messages.js";
+
+/**
+ * Resolves a `Device` instance authenticated with one of the device's own
+ * tokens, suitable for sending data.
+ *
+ * Writing data through the profile token (`resources.devices.sendDeviceData`)
+ * requires the "Device / Send data" Access Management policy, which profile
+ * tokens do not carry by default — the API answers "Authorization denied". A
+ * device token always authorizes writes to its own device, so data ingestion
+ * goes through a `Device` instance instead. Reads/deletes stay on `Resources`.
+ */
+async function getDeviceForSending(resources: Resources, deviceID: string, region: ConstructorParameters<typeof Device>[0]["region"]) {
+  const tokens = await resources.devices.tokenList(deviceID, { fields: ["token", "permission"] }).catch(errorHandler);
+  const token = tokens?.find((t) => t.permission === "full" || t.permission === "write")?.token ?? tokens?.[0]?.token;
+  if (!token) {
+    return errorHandler(`No usable token found for device ${deviceID}. Create one with: tagoio device-token ${deviceID} --create "<name>"`);
+  }
+  return new Device({ token, region });
+}
+
+export { getDeviceForSending };

--- a/src/commands/devices/device-token.test.ts
+++ b/src/commands/devices/device-token.test.ts
@@ -1,0 +1,129 @@
+import { afterEach, beforeEach, describe, expect, test, vi } from "vitest";
+
+import { makeEnvironmentConfig } from "../../test-utils/mock-config.js";
+import { makeAccount } from "../../test-utils/mock-sdk.js";
+
+const getEnvironmentConfigMock = vi.fn();
+const errorHandlerMock = vi.fn((str: unknown) => {
+  throw new Error(String(str));
+});
+const errorHandlerJSONMock = vi.fn((message: string, _code?: string) => {
+  throw new Error(`json:${message}`);
+});
+const pickDeviceIDMock = vi.fn();
+
+let resourcesInstance: ReturnType<typeof makeAccount>;
+
+vi.mock("@tago-io/sdk", () => ({
+  Resources: function Resources() {
+    return resourcesInstance;
+  },
+}));
+
+vi.mock("../../lib/config-file.js", () => ({
+  getEnvironmentConfig: getEnvironmentConfigMock,
+}));
+
+vi.mock("../../lib/messages.js", () => ({
+  errorHandler: errorHandlerMock,
+  errorHandlerJSON: errorHandlerJSONMock,
+  successMSG: vi.fn(),
+  infoMSG: vi.fn(),
+}));
+
+vi.mock("../../prompt/pick-device-id-from-tagoio.js", () => ({
+  pickDeviceIDFromTagoIO: pickDeviceIDMock,
+}));
+
+describe("deviceToken", () => {
+  let stdoutSpy: ReturnType<typeof vi.spyOn>;
+
+  beforeEach(() => {
+    resourcesInstance = makeAccount();
+    getEnvironmentConfigMock.mockReset().mockReturnValue(makeEnvironmentConfig());
+    errorHandlerMock.mockClear();
+    errorHandlerJSONMock.mockClear();
+    pickDeviceIDMock.mockReset();
+    stdoutSpy = vi.spyOn(process.stdout, "write").mockImplementation(() => true);
+    vi.spyOn(console, "table").mockImplementation(() => undefined);
+  });
+
+  afterEach(() => {
+    vi.restoreAllMocks();
+  });
+
+  test("--create sends expire_time never and default full permission", async () => {
+    resourcesInstance.devices.tokenCreate.mockResolvedValue({ token: "tok-1", permission: "full" });
+
+    const { deviceToken } = await import("./device-token.js");
+    await deviceToken("dev-1", { create: "My Token" } as never);
+
+    expect(resourcesInstance.devices.tokenCreate).toHaveBeenCalledWith(
+      "dev-1",
+      expect.objectContaining({ name: "My Token", permission: "full", expire_time: "never" }),
+    );
+  });
+
+  test("--create honors --permission", async () => {
+    resourcesInstance.devices.tokenCreate.mockResolvedValue({ token: "tok-2", permission: "read" });
+
+    const { deviceToken } = await import("./device-token.js");
+    await deviceToken("dev-1", { create: "Reader", permission: "read" } as never);
+
+    expect(resourcesInstance.devices.tokenCreate).toHaveBeenCalledWith(
+      "dev-1",
+      expect.objectContaining({ permission: "read" }),
+    );
+  });
+
+  test("--create --json emits {token, name}", async () => {
+    resourcesInstance.devices.tokenCreate.mockResolvedValue({ token: "tok-j", permission: "full" });
+
+    const { deviceToken } = await import("./device-token.js");
+    await deviceToken("dev-1", { create: "JTok", json: true } as never);
+
+    expect(JSON.parse(String(stdoutSpy.mock.calls[0][0]))).toEqual({ token: "tok-j", name: "JTok" });
+  });
+
+  test("--delete removes the token", async () => {
+    resourcesInstance.devices.tokenDelete.mockResolvedValue("removed");
+
+    const { deviceToken } = await import("./device-token.js");
+    await deviceToken("dev-1", { delete: "tok-del" } as never);
+
+    expect(resourcesInstance.devices.tokenDelete).toHaveBeenCalledWith("tok-del");
+  });
+
+  test("--delete --json emits {token, deleted:true}", async () => {
+    resourcesInstance.devices.tokenDelete.mockResolvedValue("removed");
+
+    const { deviceToken } = await import("./device-token.js");
+    await deviceToken("dev-1", { delete: "tok-d", json: true } as never);
+
+    expect(JSON.parse(String(stdoutSpy.mock.calls[0][0]))).toEqual({ token: "tok-d", deleted: true });
+  });
+
+  test("no op flag lists tokens (default)", async () => {
+    const tokens = [{ name: "T1", token: "t1", permission: "full" }];
+    resourcesInstance.devices.tokenList.mockResolvedValue(tokens);
+
+    const { deviceToken } = await import("./device-token.js");
+    await deviceToken("dev-1", { json: true } as never);
+
+    expect(resourcesInstance.devices.tokenList).toHaveBeenCalledWith("dev-1");
+    expect(JSON.parse(String(stdoutSpy.mock.calls[0][0]))).toEqual(tokens);
+  });
+
+  test("--silent with no id errors with missing_input", async () => {
+    const { deviceToken } = await import("./device-token.js");
+    await expect(deviceToken(undefined, { create: "x", silent: true, json: true } as never)).rejects.toThrow(/json:/);
+    expect(errorHandlerJSONMock).toHaveBeenCalledWith(expect.stringContaining("id"), "missing_input");
+  });
+
+  test("SDK failure on create routes through errorHandler", async () => {
+    resourcesInstance.devices.tokenCreate.mockRejectedValue(new Error("boom"));
+
+    const { deviceToken } = await import("./device-token.js");
+    await expect(deviceToken("dev-x", { create: "x" } as never)).rejects.toThrow(/Failed to create token: boom/);
+  });
+});

--- a/src/commands/devices/device-token.ts
+++ b/src/commands/devices/device-token.ts
@@ -1,0 +1,91 @@
+import { Resources } from "@tago-io/sdk";
+
+import { getEnvironmentConfig } from "../../lib/config-file.js";
+import { errorHandler, errorHandlerJSON, infoMSG, successMSG } from "../../lib/messages.js";
+import { pickDeviceIDFromTagoIO } from "../../prompt/pick-device-id-from-tagoio.js";
+
+interface IOptions {
+  environment?: string;
+  create?: string;
+  permission?: "full" | "write" | "read";
+  delete?: string;
+  list?: boolean;
+  silent?: boolean;
+  json?: boolean;
+}
+
+function failWith(message: string, code: string, useJSON: boolean): never {
+  if (useJSON) {
+    errorHandlerJSON(message, code);
+  }
+  errorHandler(message);
+}
+
+async function deviceToken(idArg: string | undefined, options: IOptions) {
+  const config = getEnvironmentConfig(options.environment);
+  if (!config || !config.profileToken) {
+    failWith("Environment not found", "env_not_found", Boolean(options.json));
+  }
+
+  const resources = new Resources({ token: config.profileToken, region: config.profileRegion });
+
+  let id = idArg;
+  if (!id) {
+    if (options.silent) {
+      failWith("Missing required input: id", "missing_input", Boolean(options.json));
+    }
+    id = await pickDeviceIDFromTagoIO(resources);
+  }
+
+  if (options.create) {
+    const name = options.create;
+    // Always pin expire_time to "never": the SDK randomly generates an
+    // expiration when the field is omitted, so the default lives here.
+    const created = await resources.devices
+      .tokenCreate(id, { name, permission: options.permission ?? "full", expire_time: "never" })
+      .catch((error: unknown) => {
+        const message = error instanceof Error ? error.message : String(error);
+        failWith(`Failed to create token: ${message}`, "token_create_failed", Boolean(options.json));
+      });
+    if (!created) {
+      return;
+    }
+    if (options.json) {
+      process.stdout.write(`${JSON.stringify({ token: created.token, name })}\n`);
+      return;
+    }
+    successMSG(`Token created for device ${id}: ${created.token}`);
+    return;
+  }
+
+  if (options.delete) {
+    const token = options.delete;
+    await resources.devices.tokenDelete(token).catch((error: unknown) => {
+      const message = error instanceof Error ? error.message : String(error);
+      failWith(`Failed to delete token: ${message}`, "token_delete_failed", Boolean(options.json));
+    });
+    if (options.json) {
+      process.stdout.write(`${JSON.stringify({ token, deleted: true })}\n`);
+      return;
+    }
+    successMSG(`Token ${token} deleted.`);
+    return;
+  }
+
+  // Default op: list tokens.
+  const tokens = await resources.devices.tokenList(id).catch((error: unknown) => {
+    const message = error instanceof Error ? error.message : String(error);
+    failWith(`Failed to list tokens: ${message}`, "token_list_failed", Boolean(options.json));
+  });
+  if (!tokens) {
+    return;
+  }
+  if (options.json) {
+    process.stdout.write(`${JSON.stringify(tokens)}\n`);
+    return;
+  }
+  console.table(tokens);
+  infoMSG(`${tokens.length} token(s) found for device ${id}.`);
+}
+
+export { deviceToken };

--- a/src/commands/devices/index.ts
+++ b/src/commands/devices/index.ts
@@ -6,9 +6,14 @@ import { changeNetworkOrConnector } from "./change-network.js";
 import { copyDeviceData } from "./copy-data.js";
 import { getDeviceData } from "./data-get.js";
 import { bkpDeviceData } from "./device-bkp.js";
+import { deviceCreate } from "./device-create.js";
+import { deviceDelete } from "./device-delete.js";
+import { deviceEdit } from "./device-edit.js";
 import { deviceInfo } from "./device-info.js";
 import { deviceList } from "./device-list.js";
 import { inspectorConnection } from "./device-live-inspector.js";
+import { deviceParam } from "./device-param.js";
+import { deviceToken } from "./device-token.js";
 
 function handleNumber(value: any, _previous: any) {
   if (Number.isNaN(Number(value))) {
@@ -19,6 +24,126 @@ function handleNumber(value: any, _previous: any) {
 
 function deviceCommands(program: Command) {
   program.command("Devices Header");
+
+  program
+    .command("device-create")
+    .description("create a new device.")
+    .argument("[name]", "name of the device")
+    .option("--env, --environment [environment]", "environment from config.js")
+    .option("--type <type>", "storage type: mutable or immutable (default: mutable)")
+    .option("--network <id>", "network ID")
+    .option("--connector <id>", "connector ID")
+    .option("--serie <serial>", "serial number (EUI / MQTT client id / IMEI)")
+    .option("--description <text>", "device description")
+    .option("--chunk-period <period>", "day|week|month|quarter (required for immutable)")
+    .option("--chunk-retention <number>", "chunks to retain, 0-36 (required for immutable)", handleNumber)
+    .option("-k, --tagkey [key]", "tag key to set (pairs with --tagvalue by index)", cmdRepeatableValue, [])
+    .option("-v, --tagvalue [value]", "tag value to set", cmdRepeatableValue, [])
+    .option("--inactive", "create the device inactive (default: active)")
+    .option("--silent", "do not prompt for missing input")
+    .option("--json", "return result as json")
+    .action(deviceCreate)
+    .addHelpText(
+      "after",
+      `
+
+Example:
+    $ tagoio device-create "Sensor A" --network 62336c32ab6e0d0012e06c04 --connector 62333bd36977fc001a2990c8
+    $ tagoio device-create "Logger" --type immutable --network <id> --connector <id> --chunk-period month --chunk-retention 3
+       `,
+    );
+
+  program
+    .command("device-delete")
+    .description("permanently delete a device and all its data.")
+    .argument("[ID/Token]", "ID/Token of your device")
+    .option("--env, --environment [environment]", "environment from config.js")
+    .option("-y, --yes", "skip the delete confirmation")
+    .option("--silent", "do not prompt (requires the device ID)")
+    .option("--json", "return result as json")
+    .action(deviceDelete)
+    .addHelpText(
+      "after",
+      `
+
+Example:
+    $ tagoio device-delete 62151835435d540010b768c4
+    $ tagoio device-delete 62151835435d540010b768c4 -y
+       `,
+    );
+
+  program
+    .command("device-edit")
+    .description("edit a device's name, tags, status, network/connector, or retention.")
+    .argument("[ID/Token]", "ID/Token of your device")
+    .option("--env, --environment [environment]", "environment from config.js")
+    .option("-n, --name <name>", "new device name")
+    .option("--description <text>", "new device description")
+    .option("--active", "set the device active")
+    .option("--inactive", "set the device inactive")
+    .option("--network <id>", "network ID")
+    .option("--connector <id>", "connector ID")
+    .option("--chunk-retention <number>", "chunks to retain, 0-36", handleNumber)
+    .option("-k, --tagkey [key]", "tag key to set (pairs with --tagvalue by index)", cmdRepeatableValue, [])
+    .option("-v, --tagvalue [value]", "tag value to set", cmdRepeatableValue, [])
+    .option("--merge-tags", "merge given tags into existing ones (default: replace the tag set)")
+    .option("--silent", "do not prompt (requires the device ID)")
+    .option("--json", "return result as json")
+    .action(deviceEdit)
+    .addHelpText(
+      "after",
+      `
+
+Example:
+    $ tagoio device-edit 62151835435d540010b768c4 --name "New Name"
+    $ tagoio device-edit 62151835435d540010b768c4 -k type -v sensor --merge-tags
+       `,
+    );
+
+  program
+    .command("device-token")
+    .description("manage device tokens: create, delete, or list.")
+    .argument("[ID/Token]", "ID/Token of your device")
+    .option("--env, --environment [environment]", "environment from config.js")
+    .option("--create <name>", "create a token with this name (expires never)")
+    .option("--permission <permission>", "token permission: full, write, or read (default: full)")
+    .option("--delete <token>", "delete a token by its value")
+    .option("--list", "list tokens (default when no other op is given)")
+    .option("--silent", "do not prompt (requires the device ID)")
+    .option("--json", "return result as json")
+    .action(deviceToken)
+    .addHelpText(
+      "after",
+      `
+
+Example:
+    $ tagoio device-token 62151835435d540010b768c4 --create "CI Token" --permission write
+    $ tagoio device-token 62151835435d540010b768c4 --list
+       `,
+    );
+
+  program
+    .command("device-param")
+    .description("manage device configuration parameters: set, delete, or list.")
+    .argument("[ID/Token]", "ID/Token of your device")
+    .option("--env, --environment [environment]", "environment from config.js")
+    .option("--set <key=value>", "set/update a param (repeatable)", cmdRepeatableValue, [])
+    .option("--sent", "mark --set params as sent (default: false)")
+    .option("--delete <paramID>", "delete a param by its id")
+    .option("--list", "list params (default when no other op is given)")
+    .option("--silent", "do not prompt (requires the device ID)")
+    .option("--json", "return result as json")
+    .action(deviceParam)
+    .addHelpText(
+      "after",
+      `
+
+Example:
+    $ tagoio device-param 62151835435d540010b768c4 --set dashboard_url=https://admin.tago.io --sent
+    $ tagoio device-param 62151835435d540010b768c4 --list
+       `,
+    );
+
   program
     .command("device-inspector")
     .alias("inspect")
@@ -95,6 +220,9 @@ Example:
     .option("--stringify", "return as text")
     .option("-p, --post <dataJSON>", "send data to the device")
     .option("-v, --var <variable>", "Filter by variable", cmdRepeatableValue, [])
+    .option("--delete", "delete data matching the filters (mutable devices only)")
+    .option("--empty", "delete ALL data on the device (mutable only); confirms unless -y")
+    .option("-y, --yes", "skip the --empty confirmation")
     .action(getDeviceData)
     .addHelpText(
       "after",
@@ -106,6 +234,8 @@ Example:
      $ tagoio data 62151835435d540010b768c4 --post '{ "variable": "temperature", "value": 32 }'
      $ tagoio data 62151835435d540010b768c4
      $ tagoio data 62151835435d540010b768c4 -v temperature -qty 1
+     $ tagoio data 62151835435d540010b768c4 --delete -v temperature
+     $ tagoio data 62151835435d540010b768c4 --empty -y
      `,
     );
 

--- a/src/lib/__snapshots__/generate-man.test.ts.snap
+++ b/src/lib/__snapshots__/generate-man.test.ts.snap
@@ -253,6 +253,178 @@ set as external or tago
 Example:
      $ tagoio analysis\\-duplicate 62151835435d540010b768c4 \\-\\-name "Duplicated Analysis"
 .fi
+.SS device\\-create [name]
+create a new device.
+.TP
+\\fB\\-\\-env\\fR, \\fB\\-\\-environment\\fR \\fI[environment]\\fR
+environment from config.js
+.TP
+\\fB\\-\\-type\\fR \\fI<type>\\fR
+storage type: mutable or immutable (default: mutable)
+.TP
+\\fB\\-\\-network\\fR \\fI<id>\\fR
+network ID
+.TP
+\\fB\\-\\-connector\\fR \\fI<id>\\fR
+connector ID
+.TP
+\\fB\\-\\-serie\\fR \\fI<serial>\\fR
+serial number (EUI / MQTT client id / IMEI)
+.TP
+\\fB\\-\\-description\\fR \\fI<text>\\fR
+device description
+.TP
+\\fB\\-\\-chunk\\-period\\fR \\fI<period>\\fR
+day|week|month|quarter (required for immutable)
+.TP
+\\fB\\-\\-chunk\\-retention\\fR \\fI<number>\\fR
+chunks to retain, 0\\-36 (required for immutable)
+.TP
+\\fB\\-k\\fR, \\fB\\-\\-tagkey\\fR \\fI[key]\\fR
+tag key to set (pairs with \\-\\-tagvalue by index) (default: [])
+.TP
+\\fB\\-v\\fR, \\fB\\-\\-tagvalue\\fR \\fI[value]\\fR
+tag value to set (default: [])
+.TP
+\\fB\\-\\-inactive\\fR
+create the device inactive (default: active)
+.TP
+\\fB\\-\\-silent\\fR
+do not prompt for missing input
+.TP
+\\fB\\-\\-json\\fR
+return result as json
+.PP
+.nf
+Example:
+    $ tagoio device\\-create "Sensor A" \\-\\-network 62336c32ab6e0d0012e06c04 \\-\\-connector 62333bd36977fc001a2990c8
+    $ tagoio device\\-create "Logger" \\-\\-type immutable \\-\\-network <id> \\-\\-connector <id> \\-\\-chunk\\-period month \\-\\-chunk\\-retention 3
+.fi
+.SS device\\-delete [ID/Token]
+permanently delete a device and all its data.
+.TP
+\\fB\\-\\-env\\fR, \\fB\\-\\-environment\\fR \\fI[environment]\\fR
+environment from config.js
+.TP
+\\fB\\-y\\fR, \\fB\\-\\-yes\\fR
+skip the delete confirmation
+.TP
+\\fB\\-\\-silent\\fR
+do not prompt (requires the device ID)
+.TP
+\\fB\\-\\-json\\fR
+return result as json
+.PP
+.nf
+Example:
+    $ tagoio device\\-delete 62151835435d540010b768c4
+    $ tagoio device\\-delete 62151835435d540010b768c4 \\-y
+.fi
+.SS device\\-edit [ID/Token]
+edit a device's name, tags, status, network/connector, or retention.
+.TP
+\\fB\\-\\-env\\fR, \\fB\\-\\-environment\\fR \\fI[environment]\\fR
+environment from config.js
+.TP
+\\fB\\-n\\fR, \\fB\\-\\-name\\fR \\fI<name>\\fR
+new device name
+.TP
+\\fB\\-\\-description\\fR \\fI<text>\\fR
+new device description
+.TP
+\\fB\\-\\-active\\fR
+set the device active
+.TP
+\\fB\\-\\-inactive\\fR
+set the device inactive
+.TP
+\\fB\\-\\-network\\fR \\fI<id>\\fR
+network ID
+.TP
+\\fB\\-\\-connector\\fR \\fI<id>\\fR
+connector ID
+.TP
+\\fB\\-\\-chunk\\-retention\\fR \\fI<number>\\fR
+chunks to retain, 0\\-36
+.TP
+\\fB\\-k\\fR, \\fB\\-\\-tagkey\\fR \\fI[key]\\fR
+tag key to set (pairs with \\-\\-tagvalue by index) (default: [])
+.TP
+\\fB\\-v\\fR, \\fB\\-\\-tagvalue\\fR \\fI[value]\\fR
+tag value to set (default: [])
+.TP
+\\fB\\-\\-merge\\-tags\\fR
+merge given tags into existing ones (default: replace the tag set)
+.TP
+\\fB\\-\\-silent\\fR
+do not prompt (requires the device ID)
+.TP
+\\fB\\-\\-json\\fR
+return result as json
+.PP
+.nf
+Example:
+    $ tagoio device\\-edit 62151835435d540010b768c4 \\-\\-name "New Name"
+    $ tagoio device\\-edit 62151835435d540010b768c4 \\-k type \\-v sensor \\-\\-merge\\-tags
+.fi
+.SS device\\-token [ID/Token]
+manage device tokens: create, delete, or list.
+.TP
+\\fB\\-\\-env\\fR, \\fB\\-\\-environment\\fR \\fI[environment]\\fR
+environment from config.js
+.TP
+\\fB\\-\\-create\\fR \\fI<name>\\fR
+create a token with this name (expires never)
+.TP
+\\fB\\-\\-permission\\fR \\fI<permission>\\fR
+token permission: full, write, or read (default: full)
+.TP
+\\fB\\-\\-delete\\fR \\fI<token>\\fR
+delete a token by its value
+.TP
+\\fB\\-\\-list\\fR
+list tokens (default when no other op is given)
+.TP
+\\fB\\-\\-silent\\fR
+do not prompt (requires the device ID)
+.TP
+\\fB\\-\\-json\\fR
+return result as json
+.PP
+.nf
+Example:
+    $ tagoio device\\-token 62151835435d540010b768c4 \\-\\-create "CI Token" \\-\\-permission write
+    $ tagoio device\\-token 62151835435d540010b768c4 \\-\\-list
+.fi
+.SS device\\-param [ID/Token]
+manage device configuration parameters: set, delete, or list.
+.TP
+\\fB\\-\\-env\\fR, \\fB\\-\\-environment\\fR \\fI[environment]\\fR
+environment from config.js
+.TP
+\\fB\\-\\-set\\fR \\fI<key=value>\\fR
+set/update a param (repeatable) (default: [])
+.TP
+\\fB\\-\\-sent\\fR
+mark \\-\\-set params as sent (default: false)
+.TP
+\\fB\\-\\-delete\\fR \\fI<paramID>\\fR
+delete a param by its id
+.TP
+\\fB\\-\\-list\\fR
+list params (default when no other op is given)
+.TP
+\\fB\\-\\-silent\\fR
+do not prompt (requires the device ID)
+.TP
+\\fB\\-\\-json\\fR
+return result as json
+.PP
+.nf
+Example:
+    $ tagoio device\\-param 62151835435d540010b768c4 \\-\\-set dashboard_url=https://admin.tago.io \\-\\-sent
+    $ tagoio device\\-param 62151835435d540010b768c4 \\-\\-list
+.fi
 .SS device\\-inspector [ID/Token]
 connect to your Device Live Inspector
 .TP
@@ -348,6 +520,15 @@ send data to the device
 .TP
 \\fB\\-v\\fR, \\fB\\-\\-var\\fR \\fI<variable>\\fR
 Filter by variable (default: [])
+.TP
+\\fB\\-\\-delete\\fR
+delete data matching the filters (mutable devices only)
+.TP
+\\fB\\-\\-empty\\fR
+delete ALL data on the device (mutable only); confirms unless \\-y
+.TP
+\\fB\\-y\\fR, \\fB\\-\\-yes\\fR
+skip the \\-\\-empty confirmation
 .PP
 .nf
 Example:
@@ -356,6 +537,8 @@ Example:
      $ tagoio data 62151835435d540010b768c4 \\-\\-post '{ "variable": "temperature", "value": 32 }'
      $ tagoio data 62151835435d540010b768c4
      $ tagoio data 62151835435d540010b768c4 \\-v temperature \\-qty 1
+     $ tagoio data 62151835435d540010b768c4 \\-\\-delete \\-v temperature
+     $ tagoio data 62151835435d540010b768c4 \\-\\-empty \\-y
 .fi
 .SS device\\-backup [ID/Token]
 backup data from a Device. Store it on TagoIO Cloud by default

--- a/src/prompt/pick-device-id-from-tagoio.test.ts
+++ b/src/prompt/pick-device-id-from-tagoio.test.ts
@@ -1,3 +1,4 @@
+import { Resources } from "@tago-io/sdk";
 import prompts from "prompts";
 import { beforeEach, describe, expect, test, vi } from "vitest";
 
@@ -40,5 +41,14 @@ describe("pickDeviceIDFromTagoIO", () => {
     prompts.inject([undefined]);
 
     await expect(pickDeviceIDFromTagoIO(account as never)).rejects.toThrow(/Device not selected/);
+  });
+
+  test("accepts a Resources instance without a cast (type-level)", async () => {
+    const { pickDeviceIDFromTagoIO } = await import("./pick-device-id-from-tagoio.js");
+    // Compile-time guarantee: the new Resources-based device commands reuse this
+    // picker. If the param were still `Account`-only, this assignment would not
+    // type-check. Not executed — the value is never constructed.
+    const _typeCheck: (resources: Resources) => Promise<string> = pickDeviceIDFromTagoIO;
+    expect(typeof _typeCheck).toBe("function");
   });
 });

--- a/src/prompt/pick-device-id-from-tagoio.ts
+++ b/src/prompt/pick-device-id-from-tagoio.ts
@@ -1,9 +1,12 @@
-import { Account } from "@tago-io/sdk";
+import { Account, Resources } from "@tago-io/sdk";
 import prompts from "prompts";
 
 import { errorHandler } from "../lib/messages.js";
 
-async function pickDeviceIDFromTagoIO(account: Account, message: string = "Which device you want to choose?") {
+// Accepts either SDK client: the legacy device commands pass `Account`, while
+// the newer `Resources`-based commands pass `Resources`. Both expose
+// `devices.list`, which is all this picker needs.
+async function pickDeviceIDFromTagoIO(account: Resources | Account, message: string = "Which device you want to choose?") {
   const deviceList = await account.devices.list({ amount: 100, fields: ["id", "name"] });
 
   const { id } = await prompts({

--- a/src/prompt/pick-files-from-tagoio.ts
+++ b/src/prompt/pick-files-from-tagoio.ts
@@ -1,4 +1,4 @@
-import { Account } from "@tago-io/sdk";
+import { Account, Resources } from "@tago-io/sdk";
 import kleur from "kleur";
 import { join } from "node:path";
 import prompts from "prompts";
@@ -7,13 +7,13 @@ import { errorHandler } from "../lib/messages.js";
 
 /**
  * Prompts the user to select a file from their TagoIO account.
- * @param account - The TagoIO account object.
+ * @param account - The TagoIO Resources or Account object (both expose files/profiles).
  * @param message - The message to display to the user.
  * @param currentPath - The current path to display to the user.
  * @returns The URL of the selected file, or undefined if the user cancels.
  */
 
-async function pickFileFromTagoIO(account: Account, message: string = "Pick the file", currentPath: string = "deviceBackup/"): Promise<string | undefined> {
+async function pickFileFromTagoIO(account: Resources | Account, message: string = "Pick the file", currentPath: string = "deviceBackup/"): Promise<string | undefined> {
   let file = { isFolder: true, name: "" };
 
   while (file.isFolder) {

--- a/src/test-utils/mock-sdk.ts
+++ b/src/test-utils/mock-sdk.ts
@@ -1,8 +1,10 @@
 import { vi, type Mock } from "vitest";
 
-// Some Account resources are nested (e.g. `account.dashboards.widgets.info`).
-// Everything else is a flat `namespace.method`.
-const NESTED_NAMESPACES = new Set(["widgets"]);
+// Some resources are nested one level deeper than `namespace.method`:
+//   `dashboards.widgets.info`, `integration.networks.info`,
+//   `integration.connectors.info`. These names resolve to another method
+//   namespace instead of a bare mock fn.
+const NESTED_NAMESPACES = new Set(["widgets", "networks", "connectors"]);
 
 type AnyRecord = Record<string, unknown>;
 


### PR DESCRIPTION
## What does PR do?

Completes device resource management in the CLI so the full lifecycle of a device can be driven from `tagoio`, and migrates the existing device commands off the deprecated `Account` SDK client onto `Resources`.

### New commands

- **device-create** — provision a device (mutable/immutable, tags, serial, chunk policy, `--inactive`).
- **device-edit** — edit name, description, active state, network/connector, retention, and tags (replace or `--merge-tags`).
- **device-delete** — permanently delete a device, with confirmation unless `-y`/`--silent`.
- **device-token** — create/list/delete device tokens (created with `expire_time: never`).
- **device-param** — set/list/delete configuration parameters.
- **data --delete / --empty** — delete matching data or clear all data on a mutable device.

### Migration to Resources

- All device commands (info, list, live-inspector, data, copy, backup, bucket-type, network) now use `Resources` instead of the deprecated `Account`.
- Data writes (post, copy, backup restore) route through a device token via a shared `getDeviceForSending` helper, because profile tokens cannot send device data.

### device-network resilience

- The API requires removing all tokens before changing network/connector. The command now validates both ids first (an invalid id never deletes a token), recreates tokens before surfacing any edit failure (avoiding a `process.exit` that would skip cleanup and leave the device tokenless), and on recreate failure reports only the tokens that actually failed.

All new commands follow the existing entities convention: `--json`/`--silent` flags, interactive picker when the ID is omitted, and actionable error codes. Verified end-to-end against a live profile for both success and error paths.

## Type of alteration

- [ ] Bug fix
- [x] New feature
- [ ] Breaking change
- [ ] Documentation update

## Tests

- Added: 56
- Removed: 0

## Risk (CIA)

- **Confidentiality:** Low. Created device tokens are printed only by the commands whose purpose is to create them; no token or profile token leaks into error messages or unrelated output. Auth is checked before every privileged operation.
- **Integrity:** Medium. Commands mutate device resources and data. Destructive operations (delete, data --empty, network change) confirm by default and the network change now guarantees tokens are never lost.
- **Availability:** Low. Short-lived CLI; respects SDK rate limits, no new polling loops.
